### PR TITLE
Fixes branch to Work as ServiceCatalog Broker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compile(group: 'org.springframework.boot', name: 'spring-boot-configuration-processor', version: springBootVersion)
     compile(group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: springBootVersion)
     compile(group: 'org.springframework.boot', name: 'spring-boot-devtools', version: springBootVersion)
+    compile(group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion)
     compile(group: 'org.springframework.cloud', name: 'spring-cloud-starter-open-service-broker',
             version: springCloudServiceBrokerVersion)
     compile(group: 'com.emc.ecs', name: 'object-client', version: '3.1.3') {

--- a/charts/templates/application.yaml
+++ b/charts/templates/application.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.serviceCatalog }}
 ---
 broker:
   object-endpoint: "https://object.ecstestdrive.com"
@@ -136,3 +137,4 @@ security:
     password: somethingsecure
 spring:
   profiles: default
+{{ end }}

--- a/charts/templates/broker.yaml
+++ b/charts/templates/broker.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.serviceCatalog }}
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ClusterServiceBroker
+metadata:
+  name: ecs-service-broker-client
+spec:
+  url: http://ecs-service-broker.{{ .Release.Namespace }}:9090
+  authInfo:
+    basic:
+      secretRef:
+        namespace: {{ .Release.Namespace }}
+        name: ecs-broker-catalog-credentials
+  catalogRestrictions:
+    serviceClass:
+      - "spec.externalName==ecs-bucket"
+{{ end }}

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -6,31 +6,14 @@ data:
   application.yml: |-
     ---
     broker:
-      object-endpoint: "http://10.243.86.70:9020"
-      management-endpoint: "https://10.243.86.70:4443"
-      namespace: "nightshift"
-      replication-group: RG
-      prefix: maddid-
-      certificate: |-
-        -----BEGIN CERTIFICATE-----
-        MIIDCTCCAfGgAwIBAgIJAJ1g36y+tM0RMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV
-        BAMTCWxvY2FsaG9zdDAeFw0yMDAyMTkxOTMzMjVaFw0zMDAyMTYxOTMzMjVaMBQx
-        EjAQBgNVBAMTCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-        ggEBAKdvGtq912EKCBNsHTYjtbRlDkJyietThHw7p3WQCUq+TBxSisPJCshWRbNr
-        vpHjygnwZOSUcmvGdjpgXZeSUTWP0jgjCaOvhgeTHCRTKpkOd+tjEFpxCDGjZ61a
-        wHWSzxHKKBCgd8v6ERgkUyaD7S6RaNVjZ6E49raiDqeGmTd1uQRVq8RzRy2HePiT
-        G+rSRfS8qP3QzAjw1pIeJU100Ihy6wmMhUhmNJlU93INziF5mg0VYbnSW/bRb7zL
-        tNVHI0jkgPDQvqPtf26TZAhIO1bBiWebEk9UUhzGtaNgFE6/k9NTpu7Z32zkvOFe
-        vu7lw0x2c24p5mkPedycrGOGkHsCAwEAAaNeMFwwHwYDVR0jBBgwFoAU2us7uV9T
-        ZvUaai/9XGPrjhRbKNswGgYDVR0RBBMwEYIJbG9jYWxob3N0hwR/AAABMB0GA1Ud
-        DgQWBBTa6zu5X1Nm9RpqL/1cY+uOFFso2zANBgkqhkiG9w0BAQsFAAOCAQEAWcrd
-        +6xY62Ctn+ijphaUOuH9GO1VCUjLRPwZc1/QfMLsss/UhJVITt7JhMMUjGcV5UyV
-        JbQwoA+vso2DUbfehTceCWOa7QXLnO7si+ujVn0/vlCLvOj7MSJeRwOD3+3b2MpV
-        AJImqfo4J7ovY4iYfKPLVO6l1B5N9Cw3F3ztcA3HfmtKS7pTA0H/TLxaJ8GVCQO+
-        d+StKXhM4dLC/uyvkPRQhXifMYJB5WM5G1X+kaiD30kZ5R0oEyWmaDrkuy2Xy0AP
-        4xCeTPYMHUQlqaUYYG4iNnMfdwJuBiTpEpxKN/zt1M+ycWXSyGSW/EkItxztO49v
-        kQjNgkCo/artraBjvQ==
-        -----END CERTIFICATE-----
+      object-endpoint: {{ .Values.api.endpoint }}
+      management-endpoint: {{ .Values.ecsConnection.endpoint }}
+      namespace: {{ .Values.namespace }}
+      replication-group: {{ .Values.replicationGroup }}
+      prefix: {{ .Values.prefix }}
+  {{- if .Values.certificate }}
+    certificate: {{ toYaml .Values.certificate | indent 6 }}
+  {{- end }}
     catalog:
       services:
       -
@@ -82,7 +65,7 @@ data:
               amount:
                 usd: 0.03
               unit: "PER GB PER MONTH"
-          name: default
+          name: unlimited
         service-settings:
           access-during-outage: true
           head-type: s3

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -1,13 +1,36 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ecs-broker
 data:
   application.yml: |-
     ---
     broker:
-      object-endpoint: "https://object.ecstestdrive.com"
-      management-endpoint: "https://portal.ecstestdrive.com"
-      namespace: "131118670375936839"
-      replication-group: ecstestdrivegeo
-      prefix: kubetesting-
+      object-endpoint: "http://10.243.86.70:9020"
+      management-endpoint: "https://10.243.86.70:4443"
+      namespace: "nightshift"
+      replication-group: RG
+      prefix: maddid-
+      certificate: |-
+        -----BEGIN CERTIFICATE-----
+        MIIDCTCCAfGgAwIBAgIJAJ1g36y+tM0RMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV
+        BAMTCWxvY2FsaG9zdDAeFw0yMDAyMTkxOTMzMjVaFw0zMDAyMTYxOTMzMjVaMBQx
+        EjAQBgNVBAMTCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+        ggEBAKdvGtq912EKCBNsHTYjtbRlDkJyietThHw7p3WQCUq+TBxSisPJCshWRbNr
+        vpHjygnwZOSUcmvGdjpgXZeSUTWP0jgjCaOvhgeTHCRTKpkOd+tjEFpxCDGjZ61a
+        wHWSzxHKKBCgd8v6ERgkUyaD7S6RaNVjZ6E49raiDqeGmTd1uQRVq8RzRy2HePiT
+        G+rSRfS8qP3QzAjw1pIeJU100Ihy6wmMhUhmNJlU93INziF5mg0VYbnSW/bRb7zL
+        tNVHI0jkgPDQvqPtf26TZAhIO1bBiWebEk9UUhzGtaNgFE6/k9NTpu7Z32zkvOFe
+        vu7lw0x2c24p5mkPedycrGOGkHsCAwEAAaNeMFwwHwYDVR0jBBgwFoAU2us7uV9T
+        ZvUaai/9XGPrjhRbKNswGgYDVR0RBBMwEYIJbG9jYWxob3N0hwR/AAABMB0GA1Ud
+        DgQWBBTa6zu5X1Nm9RpqL/1cY+uOFFso2zANBgkqhkiG9w0BAQsFAAOCAQEAWcrd
+        +6xY62Ctn+ijphaUOuH9GO1VCUjLRPwZc1/QfMLsss/UhJVITt7JhMMUjGcV5UyV
+        JbQwoA+vso2DUbfehTceCWOa7QXLnO7si+ujVn0/vlCLvOj7MSJeRwOD3+3b2MpV
+        AJImqfo4J7ovY4iYfKPLVO6l1B5N9Cw3F3ztcA3HfmtKS7pTA0H/TLxaJ8GVCQO+
+        d+StKXhM4dLC/uyvkPRQhXifMYJB5WM5G1X+kaiD30kZ5R0oEyWmaDrkuy2Xy0AP
+        4xCeTPYMHUQlqaUYYG4iNnMfdwJuBiTpEpxKN/zt1M+ycWXSyGSW/EkItxztO49v
+        kQjNgkCo/artraBjvQ==
+        -----END CERTIFICATE-----
     catalog:
       services:
       -
@@ -59,7 +82,7 @@ data:
               amount:
                 usd: 0.03
               unit: "PER GB PER MONTH"
-          name: unlimited
+          name: default
         service-settings:
           access-during-outage: true
           head-type: s3
@@ -133,11 +156,3 @@ data:
         type: bucket
     spring:
       profiles: default
-kind: ConfigMap
-metadata:
-  creationTimestamp: "2019-07-26T02:22:13Z"
-  name: ecs-broker
-  namespace: default
-  resourceVersion: "74682"
-  selfLink: /api/v1/namespaces/default/configmaps/application-yaml
-  uid: 871a8dfa-3384-4508-b1e2-03820124db5f

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ecs-service-broker
-spec: 
+spec:
   replicas: 1
   selector:
     matchLabels:
@@ -13,7 +13,7 @@ spec:
         app: ecs-service-broker
     spec:
       containers:
-        - name: ecs-broker
+        - name: ecs-service-broker
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/templates/secrets.yaml
+++ b/charts/templates/secrets.yaml
@@ -15,3 +15,15 @@ metadata:
 data:
   username: {{ default "" .Values.ecsConnection.username | b64enc | quote }}
   password: {{ default "" .Values.ecsConnection.password | b64enc | quote }}
+
+---
+{{ if .Values.serviceCatalog }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ecs-broker-catalog-credentials
+type: Opaque
+data:
+  username: {{ randAlphaNum 10 | b64enc | quote }}
+  password: {{ randAlphaNum 10 | b64enc | quote }}
+{{ end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.serviceCatalog }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: ecs-service-broker
+spec:
+  type: ClusterIP
+  ports:
+    - name: api
+      port: 9090
+      targetPort: http
+      protocol: TCP
+  selector:
+    app: ecs-service-broker
+{{ end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -59,3 +59,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Indicates this should be registered as a ServiceCatalog Broker
+serviceCatalog: false

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -4,14 +4,25 @@
 
 replicaCount: 1
 
+namespace: "131118670375936839"
+prefix: "kubetesting-"
+replicationGroup: "ecstestdrivegeo"
+
+# Management SSL Custom CA Trust Certificate
+certificate: |-
+
+# ECS Object API
 api:
   name: ecs-broker
   namespace: default
+  endpoint: "https://object.ecstestdrive.com"
   username: admin
   password: ChangeMe
 
+# ECS Management Endpoint
 ecsConnection:
   name: ecs-broker-connection
+  endpoint: "https://portal.ecstestdrive.com"
   username: <MANAGEMENT_USER>
   password: <PASSWORD>
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,16 @@
+apiVersion: skaffold/v2alpha3
+kind: Config
+build:
+  artifacts:
+    - image: ecs-service-broker
+deploy:
+  helm:
+    releases:
+      - name: ecs-service-broker-helm
+        chartPath: charts
+        values:
+          image: ecs-service-broker
+        wait: false
+        recreatePods: true
+        imageStrategy:
+          helm: {}

--- a/src/main/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflow.java
@@ -145,10 +145,14 @@ public class BucketBindingWorkflow extends BindingWorkflowImpl {
 
     @Override
     public CreateServiceInstanceAppBindingResponse getResponse(Map<String, Object> credentials) {
-        return CreateServiceInstanceAppBindingResponse.builder()
-                .credentials(credentials)
-                .volumeMounts(volumeMounts)
-                .build();
+        CreateServiceInstanceAppBindingResponse.CreateServiceInstanceAppBindingResponseBuilder builder = CreateServiceInstanceAppBindingResponse.builder()
+                .credentials(credentials);
+
+        if (volumeMounts != null) {
+                builder.volumeMounts(volumeMounts);
+        }
+
+        return builder.build();
     }
 
     private String getS3Url(URL baseUrl, String secretKey, Map<String, Object> parameters) {

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -146,7 +146,9 @@ public class EcsService {
 
     UserSecretKey createUser(String id) {
         try {
+            logger.info(String.format("Creating user %s", prefix(id)));
             ObjectUserAction.create(connection, prefix(id), broker.getNamespace());
+            logger.info(String.format("Creating secret for user %s", prefix(id)));
             ObjectUserSecretAction.create(connection, prefix(id));
             return ObjectUserSecretAction.list(connection, prefix(id)).get(0);
         } catch (Exception e) {
@@ -185,6 +187,7 @@ public class EcsService {
     }
 
     void addUserToBucket(String id, String username) {
+        logger.info(String.format("Adding user %s to bucket %s", username, id));
         try {
             addUserToBucket(id, username, Collections.singletonList("full_control"));
         } catch (Exception e) {
@@ -194,6 +197,7 @@ public class EcsService {
 
     void addUserToBucket(String id, String username,
                          List<String> permissions) throws EcsManagementClientException {
+        logger.info("Adding user {} to bucket {}", prefix(username), prefix(id));
         BucketAcl acl = BucketAclAction.get(connection, prefix(id),
                 broker.getNamespace());
         List<BucketUserAcl> userAcl = acl.getAcl().getUserAccessList();


### PR DESCRIPTION
The target branch updates the code to make it compatible with ServiceCatalog however there were still some components missing.  This PR updates the branch with:
1. Java Code Fixes
2. Helm Chart updates to register as a Broker
3. Skaffold configuration to simplify development.

**serviceCatalog Flag**
The `values.yaml` in the chart includes a `serviceCatalog` setting to allow the chart to be installed  against CF or ServiceCatalog with just a single switch.

**Testing**
The branch has been tested on a Kubernetes cluster:
After installation:
```
$ svcat get brokers
               NAME                NAMESPACE                           URL                           STATUS
+--------------------------------+-----------+-----------------------------------------------------+--------+
  ecs-service-broker-client                    http://ecs-service-broker.default:9090                Ready
```
**Provision Bucket:**
```
$ svcat provision --class ecs-bucket --plan 5gb test-bucket
  Name:        test-bucket
  Namespace:   default
  Status:
  Class:       f3cbab6a-5172-4ff1-a5c7-72990f0ce2aa
  Plan:        8e777d49-0a78-4cf4-810a-b5f5173b019d

Parameters:
  No parameters defined



$ svcat get instances
     NAME       NAMESPACE                  CLASS                                   PLAN                   STATUS
+-------------+-----------+--------------------------------------+--------------------------------------+--------+
  test-bucket   default     f3cbab6a-5172-4ff1-a5c7-72990f0ce2aa   8e777d49-0a78-4cf4-810a-b5f5173b019d   Ready
```

**Bind Bucket:**
```
$ svcat bind test-bucket  
  Name:        test-bucket
  Namespace:   default
  Status:
  Secret:      test-bucket
  Instance:    test-bucket

Parameters:
  No parameters defined
$ svcat get bindings
     NAME       NAMESPACE    INSTANCE     STATUS
+-------------+-----------+-------------+--------+
  test-bucket   default     test-bucket   Ready
```

**Resulting Secret:**
```
$ kubectl get secret test-bucket -o=yaml
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: "2020-03-23T16:09:39Z"
  name: test-bucket
  namespace: default
type: Opaque
data:
  accessKey: bWFkZGlkLTZiNjdiYmE2LWI2MmEtNDA4YS1hMjMxLWJhMThlM2RkNWJhMQ==
  bucket: bWFkZGlkLTU3ZGVlNTJhLTk4YzItNBQyMC04ZWI0LThkZTg5NzJhYWQ5NQ==
  endpoint: aHR0cDovLzEwLjI0My44Ni43MDo5MDIw
  path-style-access: dHJ1ZQ==
  s3Url: aHR0cDovL21hZGRpZC02YjY3YmJhNi11NjJhLTQwOGEtYTIzMS1iYTE4ZTNkZDViYTE6NitJM1dtc2xSVGd6YW5NaGlWNnN3ZUdpNGdESUV0NkFPdlh2ajJyNEAxMC4yNDMuODYuNzA6OTAyMC9tYWRkaWQtNTdkZWU1MmEtOThjMi00ZDIwLThlYjQtOGRlODk3MmFhZDk1
  secretKey: NitJM1dtc2xSVGd6YW5NaG2WNnN3ZUdpNGdESUV0NkFPdlh2ajJyNA==
```
