### PR TITLE
Add Multi-Stage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
+FROM gradle:4.10-jdk8 as GradleBuilder
+
+COPY --chown=gradle:gradle build.gradle /home/gradle/src/build.gradle
+COPY --chown=gradle:gradle src /home/gradle/src/src
+
+WORKDIR /home/gradle/src
+
+ENV GRADLE_USER_HOME=/home/gradle
+
+
+RUN gradle clean assemble  --stacktrace
+
+# =====================================================================================
 FROM openjdk:8-jdk-alpine
 VOLUME /tmp
-COPY build/libs/ecs-cf-service-broker-1.2.0-RELEASE.jar app.jar
+COPY --from=GradleBuilder /home/gradle/src/build/libs/ecs-cf-service-broker-*.jar app.jar


### PR DESCRIPTION
Updates the Dockerfile to be a Multi-Stage docker file that compiles the Java code before creating the final Docker image.

**Testing**
Building:
```
$ docker build --tag broker:pr-test --no-cache .
Sending build context to Docker daemon  52.24MB
Step 1/9 : FROM gradle:4.10-jdk8 as GradleBuilder
 ---> 8b87b032dac3
Step 2/9 : COPY --chown=gradle:gradle build.gradle /home/gradle/src/build.gradle
 ---> 41963747ec65
Step 3/9 : COPY --chown=gradle:gradle src /home/gradle/src/src
 ---> c697d0dbc0aa
Step 4/9 : WORKDIR /home/gradle/src
 ---> Running in b3f83eb6d103
Removing intermediate container b3f83eb6d103
 ---> cd0f31e1bcf7
Step 5/9 : ENV GRADLE_USER_HOME=/home/gradle
 ---> Running in 0f42dfe06bbe
Removing intermediate container 0f42dfe06bbe
 ---> 8fb4ee6b12cf
Step 6/9 : RUN gradle clean assemble  --stacktrace
 ---> Running in f00028bc1827

Welcome to Gradle 4.10.3!

Here are the highlights of this release:
 - Incremental Java compilation by default
 - Periodic Gradle caches cleanup
 - Gradle Kotlin DSL 1.0-RC6
 - Nested included builds
 - SNAPSHOT plugin versions in the `plugins {}` block

For more details see https://docs.gradle.org/4.10.3/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)
> Task :clean UP-TO-DATE
> Task :compileJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :processResources
> Task :classes
> Task :findMainClass
> Task :jar
> Task :bootRepackage
> Task :assemble

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 58s
6 actionable tasks: 5 executed, 1 up-to-date
Removing intermediate container f00028bc1827
 ---> 1818b79b03f7
Step 7/9 : FROM openjdk:8-jdk-alpine
 ---> a3562aa0b991
Step 8/9 : VOLUME /tmp
 ---> Running in baf546287f4b
Removing intermediate container baf546287f4b
 ---> 6086efdc95e6
Step 9/9 : COPY --from=GradleBuilder /home/gradle/src/build/libs/ecs-cf-service-broker-*.jar app.jar
 ---> e6674cef9886
Successfully built e6674cef9886
Successfully tagged broker:pr-test
```

Testing Image:
```
$ docker run -it  broker:pr-test
/ # ls -la
total 28192
drwxr-xr-x    1 root     root          4096 Apr  6 07:38 .
drwxr-xr-x    1 root     root          4096 Apr  6 07:38 ..
-rwxr-xr-x    1 root     root             0 Apr  6 07:38 .dockerenv
-rw-r--r--    1 1000     1000      28800402 Apr  6 07:37 app.jar
drwxr-xr-x    2 root     root          4096 May  9  2019 bin
drwxr-xr-x    5 root     root           360 Apr  6 07:38 dev
drwxr-xr-x    1 root     root          4096 Apr  6 07:38 etc
drwxr-xr-x    2 root     root          4096 May  9  2019 home
drwxr-xr-x    1 root     root          4096 May 11  2019 lib
drwxr-xr-x    5 root     root          4096 May  9  2019 media
drwxr-xr-x    2 root     root          4096 May  9  2019 mnt
drwxr-xr-x    2 root     root          4096 May  9  2019 opt
dr-xr-xr-x  142 root     root             0 Apr  6 07:38 proc
drwx------    1 root     root          4096 Apr  6 07:38 root
drwxr-xr-x    2 root     root          4096 May  9  2019 run
drwxr-xr-x    2 root     root          4096 May  9  2019 sbin
drwxr-xr-x    2 root     root          4096 May  9  2019 srv
dr-xr-xr-x   13 root     root             0 Apr  6 07:38 sys
drwxrwxrwt    2 root     root          4096 May  9  2019 tmp
drwxr-xr-x    1 root     root          4096 May 11  2019 usr
drwxr-xr-x    1 root     root          4096 May  9  2019 var
/ # java -jar app.jar

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::       (v1.5.21.RELEASE)

2020-04-06 07:38:52.464  INFO 8 --- [           main] c.e.e.c.broker.config.Application        : Starting Application on cb0f45673e5c with PID 8 (/app.jar started by root in /)
2020-04-06 07:38:52.468  INFO 8 --- [           main] c.e.e.c.broker.config.Application        : No active profile set, falling back to default profiles: default
2020-04-06 07:38:52.522  INFO 8 --- [           main] ationConfigEmbeddedWebApplicationContext : Refreshing org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext@63c12fb0: startup date [Mon Apr 06 07:38:52 GMT 2020]; root of context hierarchy
...
...
..
```