### PR TITLE
Issue-120 Provide Control over ECS Artifact Naming

### DIFF
--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
       replication-group: {{ .Values.replicationGroup }}
       prefix: {{ .Values.prefix }}
   {{- if .Values.certificate }}
-    certificate: {{ toYaml .Values.certificate | indent 6 }}
+      certificate: {{ toYaml .Values.certificate | indent 6 }}
   {{- end }}
     catalog:
       services:

--- a/src/main/java/com/emc/ecs/servicebroker/repository/ServiceInstance.java
+++ b/src/main/java/com/emc/ecs/servicebroker/repository/ServiceInstance.java
@@ -12,6 +12,7 @@ import java.util.*;
 @SuppressWarnings("unused")
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 public class ServiceInstance {
+    private static String NAME_PARAMETER = "name";
 
     @JsonSerialize
     @JsonProperty("service_instance_id")
@@ -73,7 +74,11 @@ public class ServiceInstance {
         serviceInstanceId = request.getServiceInstanceId();
 
         // name is set on 1st create only, not by connecting remotely
-        name = serviceInstanceId;
+        if (request.getParameters() != null && request.getParameters().containsKey(NAME_PARAMETER)) {
+            name = request.getParameters().get(NAME_PARAMETER) + "-" + serviceInstanceId;
+        } else {
+            name = serviceInstanceId;
+        }
 
         // add a reference to itself, used to find remotely created instances
         // of the same actual service instance

--- a/src/main/java/com/emc/ecs/servicebroker/repository/ServiceInstanceBinding.java
+++ b/src/main/java/com/emc/ecs/servicebroker/repository/ServiceInstanceBinding.java
@@ -13,6 +13,11 @@ import java.util.Map;
 @SuppressWarnings("unused")
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 public class ServiceInstanceBinding {
+    private static String NAME_PARAM = "name";
+
+    @JsonSerialize
+    @JsonProperty("name")
+    private String name;
 
     @JsonSerialize
     @JsonProperty("binding_id")
@@ -50,8 +55,27 @@ public class ServiceInstanceBinding {
         super();
         this.serviceDefinitionId = request.getServiceDefinitionId();
         this.planId = request.getPlanId();
+        this.bindingId = request.getBindingId();
         this.bindResource = request.getBindResource();
         this.parameters = request.getParameters();
+        this.name = getName();
+    }
+
+    // Handle old serialized instances without a name
+    public String getName() {
+        if (name != null) {
+            return name;
+        }
+
+        if (parameters != null && parameters.containsKey(NAME_PARAM)) {
+            return parameters.get(NAME_PARAM).toString() + "-" + bindingId;
+        } else {
+            return getBindingId();
+        }
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public BindResource getBindResource() {

--- a/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflow.java
@@ -20,4 +20,5 @@ public interface BindingWorkflow {
             throws IOException, EcsManagementClientException;
     ServiceInstanceBinding getBinding(Map<String, Object> credentials);
     CreateServiceInstanceAppBindingResponse getResponse(Map<String, Object> credentials);
+    void setUsername(String name);
 }

--- a/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflow.java
@@ -12,13 +12,12 @@ import java.util.Map;
 
 public interface BindingWorkflow {
     BindingWorkflow withCreateRequest(CreateServiceInstanceBindingRequest request);
-    BindingWorkflow withDeleteRequest(DeleteServiceInstanceBindingRequest request);
+    BindingWorkflow withDeleteRequest(DeleteServiceInstanceBindingRequest request, ServiceInstanceBinding existingBinding);
     void checkIfUserExists() throws EcsManagementClientException, IOException;
     String createBindingUser() throws EcsManagementClientException, IOException, JAXBException;
-    void removeBinding(ServiceInstanceBinding binding) throws EcsManagementClientException, IOException, JAXBException;
+    void removeBinding() throws EcsManagementClientException, IOException, JAXBException;
     Map<String, Object> getCredentials(String secretKey, Map<String, Object> parameters)
             throws IOException, EcsManagementClientException;
     ServiceInstanceBinding getBinding(Map<String, Object> credentials);
     CreateServiceInstanceAppBindingResponse getResponse(Map<String, Object> credentials);
-    void setUsername(String name);
 }

--- a/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflowImpl.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflowImpl.java
@@ -21,6 +21,7 @@ abstract public class BindingWorkflowImpl implements BindingWorkflow {
     String instanceId;
     String bindingId;
     CreateServiceInstanceBindingRequest createRequest;
+    String username;
 
     BindingWorkflowImpl(ServiceInstanceRepository instanceRepo, EcsService ecs) {
         this.instanceRepository = instanceRepo;
@@ -63,9 +64,21 @@ abstract public class BindingWorkflowImpl implements BindingWorkflow {
             throws IOException, EcsManagementClientException {
         Map<String, Object> credentials = new HashMap<>();
 
-        credentials.put("accessKey", ecs.prefix(bindingId));
+        credentials.put("accessKey", ecs.prefix(getUserName()));
         credentials.put("secretKey", secretKey);
 
         return credentials;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    protected String getUserName() {
+        if (username == null) {
+            username = new ServiceInstanceBinding(createRequest).getName();
+        }
+
+        return username;
     }
 }

--- a/src/main/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflow.java
@@ -32,13 +32,14 @@ public class BucketBindingWorkflow extends BindingWorkflowImpl {
     }
 
     public void checkIfUserExists() throws EcsManagementClientException, IOException {
-        if (ecs.userExists(bindingId))
+        if (ecs.userExists(getUserName()))
             throw new ServiceInstanceBindingExistsException(instanceId, bindingId);
     }
 
     @Override
     public String createBindingUser() throws EcsManagementClientException, IOException, JAXBException {
-        UserSecretKey userSecretKey = ecs.createUser(bindingId);
+        UserSecretKey userSecretKey = ecs.createUser(getUserName());
+
         Map<String, Object> parameters = createRequest.getParameters();
         ServiceInstance instance = instanceRepository.find(instanceId);
         if (instance == null)
@@ -56,14 +57,14 @@ public class BucketBindingWorkflow extends BindingWorkflowImpl {
         }
 
         if (permissions == null) {
-            ecs.addUserToBucket(bucketName, bindingId);
+            ecs.addUserToBucket(bucketName, getUserName());
         } else {
-            ecs.addUserToBucket(bucketName, bindingId, permissions);
+            ecs.addUserToBucket(bucketName, getUserName(), permissions);
         }
 
         if (ecs.getBucketFileEnabled(bucketName)) {
             volumeMounts = createVolumeExport(export,
-                    new URL(ecs.getObjectEndpoint()), parameters);
+                    new URL(ecs.getObjectEndpoint()), instance.getName(), parameters);
         }
 
         return userSecretKey.getSecretKey();
@@ -89,14 +90,14 @@ public class BucketBindingWorkflow extends BindingWorkflowImpl {
             LOG.error("Deleting user map of instance Id and Binding Id " +
                     bucketName + " " + bindingId);
             try {
-                ecs.deleteUserMap(bindingId, unixId);
+                ecs.deleteUserMap(getUserName(), unixId);
             } catch (EcsManagementClientException e) {
                 LOG.error("Error deleting user map: " + e.getMessage());
             }
         }
 
-        ecs.removeUserFromBucket(bucketName, bindingId);
-        ecs.deleteUser(bindingId);
+        ecs.removeUserFromBucket(bucketName, getUserName());
+        ecs.deleteUser(getUserName());
     }
 
     @Override
@@ -176,7 +177,7 @@ public class BucketBindingWorkflow extends BindingWorkflowImpl {
         int unixUid = (int) (2000 + System.currentTimeMillis() % 8000);
         while (true) {
             try {
-                ecs.createUserMap(bindingId, unixUid);
+                ecs.createUserMap(getUserName(), unixUid);
                 break;
             } catch (EcsManagementClientException e) {
                 if (e.getMessage().contains("Bad request body (1013)")) {
@@ -189,7 +190,7 @@ public class BucketBindingWorkflow extends BindingWorkflowImpl {
         return unixUid;
     }
 
-    private List<VolumeMount> createVolumeExport(String export, URL baseUrl, Map<String, Object> parameters)
+    private List<VolumeMount> createVolumeExport(String export, URL baseUrl, String bucketName, Map<String, Object> parameters)
             throws EcsManagementClientException {
         int unixUid = createUserMap();
         String host = ecs.getNfsMountHost();
@@ -197,9 +198,9 @@ public class BucketBindingWorkflow extends BindingWorkflowImpl {
             host = baseUrl.getHost();
         }
 
-        LOG.info("Adding export:  " + export + " to bucket: " + instanceId);
+        LOG.info("Adding export:  " + export + " to bucket: " + bucketName);
         String volumeGUID = UUID.randomUUID().toString();
-        String absoluteExportPath = ecs.addExportToBucket(instanceId, export);
+        String absoluteExportPath = ecs.addExportToBucket(bucketName, export);
         LOG.info("export added.");
 
         Map<String, Object> opts = new HashMap<>();

--- a/src/main/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflow.java
@@ -5,6 +5,7 @@ import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 
 import java.io.IOException;
 import java.util.Map;
@@ -17,8 +18,17 @@ public class BucketInstanceWorkflow extends InstanceWorkflowImpl {
     }
 
     @Override
-    public Map<String, Object> changePlan(String instanceName, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters) {
-        return ecs.changeBucketPlan(instanceName, service, plan, parameters);
+    public Map<String, Object> changePlan(String instanceId, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters) {
+        try {
+            ServiceInstance instance = instanceRepository.find(instanceId);
+            if (instance == null) {
+                throw new ServiceInstanceDoesNotExistException(instanceId);
+            }
+
+            return ecs.changeBucketPlan(instance.getName(), service, plan, parameters);
+        } catch (IOException e) {
+            throw new ServiceBrokerException(e);
+        }
     }
     @Override
     public void delete(String id) {

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -80,7 +80,7 @@ public class EcsService {
                                      PlanProxy plan, Map<String, Object> parameters) {
         if (parameters == null) parameters = new HashMap<>();
 
-        logger.info(String.format("Creating bucket %s", id));
+        logger.debug(String.format("Creating bucket %s", id));
         try {
             if (bucketExists(id)) {
                 throw new ServiceInstanceExistsException(id, service.getId());
@@ -146,9 +146,9 @@ public class EcsService {
 
     UserSecretKey createUser(String id) {
         try {
-            logger.info(String.format("Creating user %s", prefix(id)));
+            logger.debug(String.format("Creating user %s", prefix(id)));
             ObjectUserAction.create(connection, prefix(id), broker.getNamespace());
-            logger.info(String.format("Creating secret for user %s", prefix(id)));
+            logger.debug(String.format("Creating secret for user %s", prefix(id)));
             ObjectUserSecretAction.create(connection, prefix(id));
             return ObjectUserSecretAction.list(connection, prefix(id)).get(0);
         } catch (Exception e) {
@@ -187,7 +187,7 @@ public class EcsService {
     }
 
     void addUserToBucket(String id, String username) {
-        logger.info(String.format("Adding user %s to bucket %s", username, id));
+        logger.debug(String.format("Adding user %s to bucket %s", username, id));
         try {
             addUserToBucket(id, username, Collections.singletonList("full_control"));
         } catch (Exception e) {
@@ -197,7 +197,7 @@ public class EcsService {
 
     void addUserToBucket(String id, String username,
                          List<String> permissions) throws EcsManagementClientException {
-        logger.info("Adding user {} to bucket {}", prefix(username), prefix(id));
+        logger.debug("Adding user {} to bucket {}", prefix(username), prefix(id));
         BucketAcl acl = BucketAclAction.get(connection, prefix(id),
                 broker.getNamespace());
         List<BucketUserAcl> userAcl = acl.getAcl().getUserAccessList();

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -125,7 +125,7 @@ public class EcsService {
                                      PlanProxy plan, Map<String, Object> parameters) {
         if (parameters == null) parameters = new HashMap<>();
 
-        logger.info(String.format("Creating bucket %s", bucketName));
+        logger.info(String.format("Creating bucket %s", prefix(bucketName)));
         try {
             if (bucketExists(bucketName)) {
                 throw new ServiceInstanceExistsException(id, service.getId());
@@ -461,7 +461,7 @@ public class EcsService {
     Map<String, Object> createNamespace(String namespace, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters)
             throws EcsManagementClientException {
         if (namespaceExists(prefix(namespace))) {
-            throw new ServiceInstanceExistsException(id, service.getId());
+            throw new ServiceInstanceExistsException(namespace, service.getId());
         }
 
         if (parameters == null) parameters = new HashMap<>();

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -156,34 +156,34 @@ public class EcsService {
         }
     }
 
-    UserSecretKey createUser(String id, String namespace)
+    UserSecretKey createUser(String username, String namespace)
             throws EcsManagementClientException {
-        ObjectUserAction.create(connection, prefix(id), prefix(namespace));
-        ObjectUserSecretAction.create(connection, prefix(id));
-        return ObjectUserSecretAction.list(connection, prefix(id)).get(0);
+        ObjectUserAction.create(connection, prefix(username), prefix(namespace));
+        ObjectUserSecretAction.create(connection, prefix(username));
+        return ObjectUserSecretAction.list(connection, prefix(username)).get(0);
     }
 
-    void createUserMap(String id, int uid)
+    void createUserMap(String username, int uid)
             throws EcsManagementClientException {
-        ObjectUserMapAction.create(connection, prefix(id), uid, broker.getNamespace());
+        ObjectUserMapAction.create(connection, prefix(username), uid, broker.getNamespace());
     }
 
-    void deleteUserMap(String id, String uid)
+    void deleteUserMap(String username, String uid)
             throws EcsManagementClientException {
-        ObjectUserMapAction.delete(connection, prefix(id), uid, broker.getNamespace());
+        ObjectUserMapAction.delete(connection, prefix(username), uid, broker.getNamespace());
     }
 
-    Boolean userExists(String id) throws ServiceBrokerException {
+    Boolean userExists(String userId) throws ServiceBrokerException {
         try {
-            return ObjectUserAction.exists(connection, prefix(id),
+            return ObjectUserAction.exists(connection, prefix(userId),
                     broker.getNamespace());
         } catch (Exception e) {
             throw new ServiceBrokerException(e);
         }
     }
 
-    void deleteUser(String id) throws EcsManagementClientException {
-        ObjectUserAction.delete(connection, prefix(id));
+    void deleteUser(String userId) throws EcsManagementClientException {
+        ObjectUserAction.delete(connection, prefix(userId));
     }
 
     void addUserToBucket(String id, String username) {

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -63,16 +63,16 @@ public class EcsService {
         }
     }
 
-    void deleteBucket(String id) {
+    void deleteBucket(String bucketName) {
         try {
-            BucketAction.delete(connection, prefix(id), broker.getNamespace());
+            BucketAction.delete(connection, prefix(bucketName), broker.getNamespace());
         } catch (Exception e) {
             throw new ServiceBrokerException(e);
         }
     }
 
-    Boolean getBucketFileEnabled(String id) throws EcsManagementClientException {
-        ObjectBucketInfo b = BucketAction.get(connection, prefix(id), broker.getNamespace());
+    Boolean getBucketFileEnabled(String bucketName) throws EcsManagementClientException {
+        ObjectBucketInfo b = BucketAction.get(connection, prefix(bucketName), broker.getNamespace());
         return b.getFsAccessEnabled();
     }
 

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -85,7 +85,7 @@ public class EcsService {
 
     CompletableFuture deleteBucket(String bucketName) {
         try {
-            if (bucketExists(id)) {
+            if (bucketExists(bucketName)) {
                 BucketAction.delete(connection, prefix(bucketName), broker.getNamespace());
             } else {
                 logger.info("Bucket {} no longer exists, assume already deleted", prefix(bucketName));

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingService.java
@@ -72,6 +72,7 @@ public class EcsServiceInstanceBindingService
 
             return Mono.just(workflow.getResponse(credentials));
         } catch (IOException | JAXBException | EcsManagementClientException e) {
+            LOG.error("Error ", e);
             throw new ServiceBrokerException(e);
         }
     }
@@ -87,6 +88,7 @@ public class EcsServiceInstanceBindingService
 
             LOG.info("looking up binding: " + bindingId);
             ServiceInstanceBinding binding = repository.find(bindingId);
+            workflow.setUsername(binding.getName());
             if (binding == null)
                 throw new ServiceInstanceBindingDoesNotExistException(bindingId);
             LOG.info("binding found: " + bindingId);

--- a/src/main/java/com/emc/ecs/servicebroker/service/NamespaceBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/NamespaceBindingWorkflow.java
@@ -21,7 +21,7 @@ public class NamespaceBindingWorkflow extends BindingWorkflowImpl {
     }
 
     public void checkIfUserExists() throws EcsManagementClientException, IOException {
-        if (ecs.userExists(bindingId))
+        if (ecs.userExists(getUserName()))
             throw new ServiceInstanceBindingExistsException(instanceId, bindingId);
     }
 
@@ -35,12 +35,12 @@ public class NamespaceBindingWorkflow extends BindingWorkflowImpl {
             instance.setName(instance.getServiceInstanceId());
         String namespaceName = instance.getName();
 
-        return ecs.createUser(bindingId, namespaceName).getSecretKey();
+        return ecs.createUser(getUserName(), namespaceName).getSecretKey();
     }
 
     @Override
     public void removeBinding(ServiceInstanceBinding binding) throws EcsManagementClientException {
-        ecs.deleteUser(bindingId);
+        ecs.deleteUser(getUserName());
     }
 
     @Override

--- a/src/main/java/com/emc/ecs/servicebroker/service/NamespaceBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/NamespaceBindingWorkflow.java
@@ -36,12 +36,12 @@ public class NamespaceBindingWorkflow extends BindingWorkflowImpl {
             instance.setName(instance.getServiceInstanceId());
         String namespaceName = instance.getName();
 
-        return ecs.createUser(getUserName(), namespaceName).getSecretKey();
+        return ecs.createUser(binding.getName(), namespaceName).getSecretKey();
     }
 
     @Override
-    public void removeBinding(ServiceInstanceBinding binding) throws EcsManagementClientException {
-        ecs.deleteUser(getUserName());
+    public void removeBinding() throws EcsManagementClientException {
+        ecs.deleteUser(binding.getName());
     }
 
     @Override

--- a/src/main/java/com/emc/ecs/servicebroker/service/NamespaceInstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/NamespaceInstanceWorkflow.java
@@ -20,8 +20,8 @@ public class NamespaceInstanceWorkflow extends InstanceWorkflowImpl {
     }
 
     @Override
-    public Map<String, Object> changePlan(String id, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters) throws EcsManagementClientException, IOException {
-        return ecs.changeNamespacePlan(id, service, plan, parameters);
+    public Map<String, Object> changePlan(String instanceName, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters) throws EcsManagementClientException, IOException {
+        return ecs.changeNamespacePlan(instanceName, service, plan, parameters);
     }
 
     @Override
@@ -31,7 +31,7 @@ public class NamespaceInstanceWorkflow extends InstanceWorkflowImpl {
             if (instance.getReferences().size() > 1) {
                 removeInstanceFromReferences(instance, id);
             } else {
-                ecs.deleteNamespace(id);
+                ecs.deleteNamespace(instance.getName());
             }
         } catch (EcsManagementClientException | JAXBException | IOException e) {
             throw new ServiceBrokerException(e);
@@ -54,8 +54,12 @@ public class NamespaceInstanceWorkflow extends InstanceWorkflowImpl {
 
     @Override
     public ServiceInstance create(String id, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters)
-            throws EcsManagementClientException, EcsManagementResourceNotFoundException {
-        Map<String, Object> serviceSettings = ecs.createNamespace(id, service, plan, parameters);
-        return getServiceInstance(serviceSettings);
+        throws EcsManagementClientException, EcsManagementResourceNotFoundException {
+        ServiceInstance instance = getServiceInstance(parameters);
+        Map<String, Object> serviceSettings = ecs.createNamespace(instance.getName(), service, plan, parameters);
+
+        instance.setServiceSettings(serviceSettings);
+
+        return instance;
     }
 }

--- a/src/main/java/com/emc/ecs/servicebroker/service/NamespaceInstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/NamespaceInstanceWorkflow.java
@@ -7,6 +7,7 @@ import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 
 import javax.xml.bind.JAXBException;
 import java.io.IOException;
@@ -20,8 +21,17 @@ public class NamespaceInstanceWorkflow extends InstanceWorkflowImpl {
     }
 
     @Override
-    public Map<String, Object> changePlan(String instanceName, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters) throws EcsManagementClientException, IOException {
-        return ecs.changeNamespacePlan(instanceName, service, plan, parameters);
+    public Map<String, Object> changePlan(String id, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters) throws EcsManagementClientException, IOException {
+        try {
+            ServiceInstance instance = instanceRepository.find(id);
+            if (instance == null) {
+                throw new ServiceInstanceDoesNotExistException(id);
+            }
+
+            return ecs.changeNamespacePlan(instance.getName(), service, plan, parameters);
+        } catch (IOException e) {
+            throw new ServiceBrokerException(e);
+        }
     }
 
     @Override

--- a/src/main/java/com/emc/ecs/servicebroker/service/RemoteConnectBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/RemoteConnectBindingWorkflow.java
@@ -49,7 +49,7 @@ public class RemoteConnectBindingWorkflow extends BindingWorkflowImpl {
     }
 
     @Override
-    public void removeBinding(ServiceInstanceBinding binding)
+    public void removeBinding()
             throws EcsManagementClientException, IOException, JAXBException {
         ServiceInstance instance = instanceRepository.find(instanceId);
         if (instance == null)

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -176,15 +176,19 @@ public class Fixtures {
     }
 
     public static CreateServiceInstanceRequest namespaceCreateRequestFixture(Map<String, Object> params) {
+        return namespaceCreateRequestFixture(SERVICE_INSTANCE_ID, params);
+    }
+
+    public static CreateServiceInstanceRequest namespaceCreateRequestFixture(String instanceId, Map<String, Object> params) {
         return CreateServiceInstanceRequest.builder()
                 .serviceDefinitionId(NAMESPACE_SERVICE_ID)
                 .planId(NAMESPACE_PLAN_ID1)
                 .parameters(params)
-                .serviceInstanceId(SERVICE_INSTANCE_ID)
+                .serviceInstanceId(instanceId)
                 .build();
     }
 
-    public static CreateServiceInstanceRequest bucketCreateRequestFixture(Map<String, Object> params) {
+     public static CreateServiceInstanceRequest bucketCreateRequestFixture(Map<String, Object> params) {
         return CreateServiceInstanceRequest.builder()
                 .serviceDefinitionId(BUCKET_SERVICE_ID)
                 .planId(BUCKET_PLAN_ID1)
@@ -223,11 +227,15 @@ public class Fixtures {
     }
 
     public static DeleteServiceInstanceRequest namespaceDeleteRequestFixture() {
+        return namespaceDeleteRequestFixture(NAMESPACE);
+    }
+
+    public static DeleteServiceInstanceRequest namespaceDeleteRequestFixture(String instanceId) {
         return DeleteServiceInstanceRequest.builder()
-                .serviceDefinitionId(NAMESPACE_SERVICE_ID)
-                .planId(NAMESPACE_PLAN_ID1)
-                .serviceInstanceId(NAMESPACE)
-                .build();
+            .serviceDefinitionId(NAMESPACE_SERVICE_ID)
+            .planId(NAMESPACE_PLAN_ID1)
+            .serviceInstanceId(instanceId)
+            .build();
     }
 
     public static DeleteServiceInstanceRequest bucketDeleteRequestFixture() {

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -364,6 +364,20 @@ public class Fixtures {
         return new ServiceInstance(createReq);
     }
 
+    public static ServiceInstance serviceInstanceWithNameFixture(String name) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", name);
+
+        CreateServiceInstanceRequest createReq = CreateServiceInstanceRequest.builder()
+            .serviceInstanceId(SERVICE_INSTANCE_ID)
+            .serviceDefinitionId("service-one-id")
+            .planId("plan-one-id")
+            .parameters(params)
+            .build();
+        return new ServiceInstance(createReq);
+    }
+
+
     public static ServiceInstanceBinding bindingInstanceFixture() {
         Map<String, Object> creds = new HashMap<>();
         creds.put("accessKey", "user");

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -341,10 +341,18 @@ public class Fixtures {
     }
 
     public static CreateServiceInstanceBindingRequest bucketBindingRequestFixture() {
+        return bucketBindingRequestWithNameFixture(null);
+    }
+
+    public static CreateServiceInstanceBindingRequest bucketBindingRequestWithNameFixture(String name) {
         BindResource bindResource = BindResource.builder()
                 .appGuid(APP_GUID)
                 .build();
         Map<String, Object> params = new HashMap<>();
+        if (name != null) {
+            params.put("name", name);
+        }
+
         return CreateServiceInstanceBindingRequest.builder()
                 .serviceDefinitionId(BUCKET_SERVICE_ID)
                 .planId(BUCKET_PLAN_ID1)
@@ -377,8 +385,11 @@ public class Fixtures {
         return new ServiceInstance(createReq);
     }
 
-
     public static ServiceInstanceBinding bindingInstanceFixture() {
+        return bindingInstanceWithNameFixture(null);
+    }
+
+    public static ServiceInstanceBinding bindingInstanceWithNameFixture(String name) {
         Map<String, Object> creds = new HashMap<>();
         creds.put("accessKey", "user");
         creds.put("bucket", "bucket");
@@ -393,6 +404,11 @@ public class Fixtures {
         params.put("flag", true);
         params.put("text", "abcdefg");
         params.put("nested", nested);
+
+        if (name != null) {
+            params.put("name", name);
+        }
+
         BindResource bindResource = BindResource.builder()
                 .appGuid("app-guid")
                 .build();
@@ -400,9 +416,10 @@ public class Fixtures {
                 .planId("plan-one-id")
                 .bindResource(bindResource)
                 .parameters(params)
+                .bindingId(BINDING_ID)
                 .build();
         ServiceInstanceBinding binding = new ServiceInstanceBinding(createReq);
-        binding.setBindingId("service-inst-bind-one-id");
+        binding.setBindingId(BINDING_ID);
         binding.setServiceDefinitionId("service-one-id");
         binding.setCredentials(creds);
         return binding;

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -213,7 +213,7 @@ public class Fixtures {
                 .serviceDefinitionId(NAMESPACE_SERVICE_ID)
                 .planId(NAMESPACE_PLAN_ID1)
                 .parameters(params)
-                .serviceInstanceId(NAMESPACE)
+                .serviceInstanceId(SERVICE_INSTANCE_ID)
                 .build();
     }
 

--- a/src/test/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflowTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflowTest.java
@@ -1,5 +1,6 @@
 package com.emc.ecs.servicebroker.service;
 
+import com.emc.ecs.common.Fixtures;
 import com.emc.ecs.management.sdk.model.UserSecretKey;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceBinding;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
@@ -43,7 +44,8 @@ public class BucketBindingWorkflowTest {
             BeforeEach(() -> {
                 ecs = mock(EcsService.class);
                 instanceRepo = mock(ServiceInstanceRepository.class);
-                workflow = new BucketBindingWorkflow(instanceRepo, ecs);
+                workflow = new BucketBindingWorkflow(instanceRepo, ecs)
+                    .withCreateRequest(Fixtures.bucketBindingRequestFixture());
             });
 
             Context("with binding ID conflict", () -> {

--- a/src/test/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflowTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflowTest.java
@@ -82,7 +82,8 @@ public class BucketBindingWorkflowTest {
 
                     It("should throw a service-does-not-exist exception on removeBinding", () -> {
                         try {
-                            workflow.removeBinding(bindingInstanceFixture());
+                            workflow.withDeleteRequest(bucketBindingRemoveFixture(), bindingInstanceFixture());
+                            workflow.removeBinding();
                         } catch (ServiceInstanceDoesNotExistException e) {
                             assert e.getClass().equals(ServiceInstanceDoesNotExistException.class);
                         }
@@ -147,15 +148,19 @@ public class BucketBindingWorkflowTest {
                         });
 
                         It("should delete the user", () -> {
-                            workflow.removeBinding(bindingInstanceFixture());
+                            ServiceInstanceBinding existingBinding = bindingInstanceFixture();
+                            workflow.withDeleteRequest(bucketBindingRemoveFixture(), existingBinding);
+                            workflow.removeBinding();
                             verify(ecs, times(1))
-                                    .deleteUser(BINDING_ID);
+                                    .deleteUser(existingBinding.getName());
                         });
 
                         It("should remove the user from a bucket", () -> {
-                            workflow.removeBinding(bindingInstanceFixture());
+                            ServiceInstanceBinding existingBinding = bindingInstanceFixture();
+                            workflow.withDeleteRequest(bucketBindingRemoveFixture(), existingBinding);
+                            workflow.removeBinding();
                             verify(ecs, times(1))
-                                    .removeUserFromBucket(SERVICE_INSTANCE_ID, BINDING_ID);
+                                    .removeUserFromBucket(SERVICE_INSTANCE_ID, existingBinding.getName());
                         });
 
 
@@ -269,11 +274,14 @@ public class BucketBindingWorkflowTest {
                             });
 
                             It("should delete the NFS export", () -> {
-                                workflow.removeBinding(bindingInstanceVolumeMountFixture());
+                                ServiceInstanceBinding existingBinding = bindingInstanceVolumeMountFixture();
+                                workflow.withDeleteRequest(bucketBindingRemoveFixture(), existingBinding);
+                                workflow.removeBinding();
+
                                 verify(ecs, times(1))
-                                        .deleteUser(BINDING_ID);
+                                        .deleteUser(existingBinding.getName());
                                 verify(ecs, times(1))
-                                        .deleteUserMap(eq(BINDING_ID), eq("456"));
+                                        .deleteUserMap(eq(existingBinding.getName()), eq("456"));
                             });
 
                             It("should return a binding mount", () -> {

--- a/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
@@ -54,11 +54,11 @@ public class BucketInstanceWorkflowTest {
                 Context("with multiple references", () -> {
                     BeforeEach(() -> {
                         Set<String> refs = new HashSet<>(Arrays.asList(
-                                BUCKET_NAME,
+                                SERVICE_INSTANCE_ID,
                                 BUCKET_NAME + "2"
                         ));
                         bucketInstance.setReferences(refs);
-                        when(instanceRepo.find(BUCKET_NAME))
+                        when(instanceRepo.find(SERVICE_INSTANCE_ID))
                                 .thenReturn(bucketInstance);
                         when(instanceRepo.find(BUCKET_NAME + "2"))
                                 .thenReturn(bucketInstance);
@@ -66,13 +66,13 @@ public class BucketInstanceWorkflowTest {
 
                     Context("the bucket is included in references", () -> {
                         It("should not delete the bucket", () -> {
-                            workflow.delete(BUCKET_NAME);
+                            workflow.delete(SERVICE_INSTANCE_ID);
                             verify(ecs, times(0))
-                                    .deleteBucket(BUCKET_NAME);
+                                    .deleteBucket(SERVICE_INSTANCE_ID);
                         });
 
                         It("should update each references", () -> {
-                            workflow.delete(BUCKET_NAME);
+                            workflow.delete(SERVICE_INSTANCE_ID);
                             verify(instanceRepo, times(1))
                                     .save(instCaptor.capture());
                             ServiceInstance savedInst = instCaptor.getValue();
@@ -87,15 +87,15 @@ public class BucketInstanceWorkflowTest {
                     BeforeEach(() -> {
                         Set<String> refs = new HashSet<>(Collections.singletonList(BUCKET_NAME));
                         bucketInstance.setReferences(refs);
-                        when(instanceRepo.find(BUCKET_NAME))
+                        when(instanceRepo.find(SERVICE_INSTANCE_ID))
                                 .thenReturn(bucketInstance);
-                        doNothing().when(ecs).deleteBucket(BUCKET_NAME);
+                        doNothing().when(ecs).deleteBucket(SERVICE_INSTANCE_ID);
                     });
 
                     It("should delete the bucket", () -> {
-                        workflow.delete(BUCKET_NAME);
+                        workflow.delete(SERVICE_INSTANCE_ID);
                         verify(ecs, times(1))
-                                .deleteBucket(BUCKET_NAME);
+                                .deleteBucket(SERVICE_INSTANCE_ID);
                     });
                 });
             });

--- a/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
@@ -97,15 +97,15 @@ public class BucketInstanceWorkflowTest {
 
                 BeforeEach(() -> {
                     doNothing().when(instanceRepo).save(any(ServiceInstance.class));
-                    when(instanceRepo.find(BUCKET_NAME)).thenReturn(bucketInstance);
+                    when(instanceRepo.find(SERVICE_INSTANCE_ID)).thenReturn(bucketInstance);
                 });
 
                 Context("with no ReclaimPolicy", () -> {
                     It("should call delete and NOT wipe bucket", () -> {
-                        CompletableFuture result = workflow.delete(BUCKET_NAME);
+                        CompletableFuture result = workflow.delete(SERVICE_INSTANCE_ID);
                         assertNull(result);
-                        verify(ecs, times(1)).deleteBucket(BUCKET_NAME);
-                        verify(ecs, times(0)).wipeAndDeleteBucket(BUCKET_NAME);
+                        verify(ecs, times(1)).deleteBucket(bucketInstance.getName());
+                        verify(ecs, times(0)).wipeAndDeleteBucket(bucketInstance.getName());
                     });
                 });
 
@@ -113,10 +113,10 @@ public class BucketInstanceWorkflowTest {
                     It("should call delete and NOT wipe bucket", () -> {
                         bucketInstance.setServiceSettings(Collections.singletonMap(RECLAIM_POLICY, ReclaimPolicy.Fail));
 
-                        CompletableFuture result = workflow.delete(BUCKET_NAME);
+                        CompletableFuture result = workflow.delete(SERVICE_INSTANCE_ID);
                         assertNull(result);
-                        verify(ecs, times(1)).deleteBucket(BUCKET_NAME);
-                        verify(ecs, times(0)).wipeAndDeleteBucket(BUCKET_NAME);
+                        verify(ecs, times(1)).deleteBucket(bucketInstance.getName());
+                        verify(ecs, times(0)).wipeAndDeleteBucket(bucketInstance.getName());
                     });
                 });
 
@@ -124,10 +124,10 @@ public class BucketInstanceWorkflowTest {
                     It("should not call delete", () -> {
                         bucketInstance.setServiceSettings(Collections.singletonMap(RECLAIM_POLICY, ReclaimPolicy.Detach));
 
-                        CompletableFuture result = workflow.delete(BUCKET_NAME);
+                        CompletableFuture result = workflow.delete(SERVICE_INSTANCE_ID);
                         assertNull(result);
-                        verify(ecs, times(0)).deleteBucket(BUCKET_NAME);
-                        verify(ecs, times(0)).wipeAndDeleteBucket(BUCKET_NAME);
+                        verify(ecs, times(0)).deleteBucket(bucketInstance.getName());
+                        verify(ecs, times(0)).wipeAndDeleteBucket(bucketInstance.getName());
                     });
                 });
 
@@ -135,10 +135,10 @@ public class BucketInstanceWorkflowTest {
                     It("should wipe and delete", () -> {
                         bucketInstance.setServiceSettings(Collections.singletonMap(RECLAIM_POLICY, ReclaimPolicy.Delete));
 
-                        CompletableFuture result = workflow.delete(BUCKET_NAME);
+                        CompletableFuture result = workflow.delete(SERVICE_INSTANCE_ID);
                         assertNotNull(result);
-                        verify(ecs, times(0)).deleteBucket(BUCKET_NAME);
-                        verify(ecs, times(1)).wipeAndDeleteBucket(BUCKET_NAME);
+                        verify(ecs, times(0)).deleteBucket(bucketInstance.getName());
+                        verify(ecs, times(1)).wipeAndDeleteBucket(bucketInstance.getName());
                     });
                 });
             });
@@ -200,7 +200,7 @@ public class BucketInstanceWorkflowTest {
                     BeforeEach(() -> {
                         when(instanceRepo.find(SERVICE_INSTANCE_ID))
                             .thenReturn(namedBucketInstance);
-                        doNothing().when(ecs).deleteBucket(SERVICE_INSTANCE_ID);
+                        when(ecs.deleteBucket(SERVICE_INSTANCE_ID)).thenReturn(CompletableFuture.completedFuture(true));
                     });
 
                     It("should delete the named bucket", () -> {

--- a/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
@@ -106,7 +106,7 @@ public class BucketInstanceWorkflowTest {
 
             Context("#create", () -> {
                 BeforeEach(() -> {
-                    when(ecs.createBucket(BUCKET_NAME, serviceProxy, planProxy, parameters))
+                    when(ecs.createBucket(BUCKET_NAME, BUCKET_NAME,  serviceProxy, planProxy, parameters))
                             .thenReturn(new HashMap<>());
                     workflow.withCreateRequest(bucketCreateRequestFixture(parameters));
                 });
@@ -114,7 +114,7 @@ public class BucketInstanceWorkflowTest {
                 It("should create the bucket", () -> {
                     workflow.create(BUCKET_NAME, serviceProxy, planProxy, parameters);
                     verify(ecs, times(1))
-                            .createBucket(BUCKET_NAME, serviceProxy, planProxy, parameters);
+                            .createBucket(BUCKET_NAME, BUCKET_NAME, serviceProxy, planProxy, parameters);
                 });
 
                 It("should return the service instance", () -> {

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingServiceTest.java
@@ -344,10 +344,11 @@ public class EcsServiceInstanceBindingServiceTest {
     @Test
     public void testRemoveNamespaceUser() throws EcsManagementClientException, IOException {
         when(ecs.lookupServiceDefinition(NAMESPACE_SERVICE_ID)).thenReturn(namespaceServiceFixture());
-        when(repository.find(eq(BINDING_ID))).thenReturn(bindingInstanceFixture());
+        ServiceInstanceBinding bindingFixture = bindingInstanceFixture();
+        when(repository.find(eq(BINDING_ID))).thenReturn(bindingFixture);
         bindSvc.deleteServiceInstanceBinding(namespaceBindingRemoveFixture());
-        verify(ecs, times(1)).deleteUser(BINDING_ID);
-        verify(ecs, times(0)).removeUserFromBucket(NAMESPACE, BINDING_ID);
+        verify(ecs, times(1)).deleteUser(bindingFixture.getName());
+        verify(ecs, times(0)).removeUserFromBucket(NAMESPACE, bindingFixture.getName());
     }
 
     /**
@@ -356,11 +357,12 @@ public class EcsServiceInstanceBindingServiceTest {
     @Test
     public void testRemoveBucketUser() throws EcsManagementClientException, IOException {
         when(ecs.lookupServiceDefinition(BUCKET_SERVICE_ID)).thenReturn(bucketServiceFixture());
-        when(repository.find(eq(BINDING_ID))).thenReturn(bindingInstanceFixture());
+        ServiceInstanceBinding bindingFixture = bindingInstanceFixture();
+        when(repository.find(eq(BINDING_ID))).thenReturn(bindingFixture);
         when(instanceRepository.find(SERVICE_INSTANCE_ID)).thenReturn(serviceInstanceFixture());
         bindSvc.deleteServiceInstanceBinding(bucketBindingRemoveFixture());
-        verify(ecs, times(1)).removeUserFromBucket(SERVICE_INSTANCE_ID, BINDING_ID);
-        verify(ecs, times(1)).deleteUser(BINDING_ID);
+        verify(ecs, times(1)).removeUserFromBucket(SERVICE_INSTANCE_ID, bindingFixture.getName());
+        verify(ecs, times(1)).deleteUser(bindingFixture.getName());
     }
 
     /**

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceServiceTest.java
@@ -57,14 +57,14 @@ public class EcsServiceInstanceServiceTest {
 
                         BeforeEach(() -> {
                             createReq = bucketCreateRequestFixture(params);
-                            when(ecs.createBucket(BUCKET_NAME, serviceDef, plan, params))
+                            when(ecs.createBucket(BUCKET_NAME, BUCKET_NAME, serviceDef, plan, params))
                                     .thenReturn(settings);
                             instSvc.createServiceInstance(createReq);
                         });
 
                         It("should create the bucket", () ->
                                 verify(ecs, times(1))
-                                        .createBucket(BUCKET_NAME, serviceDef, plan, params));
+                                        .createBucket(BUCKET_NAME, BUCKET_NAME,  serviceDef, plan, params));
 
                         It("should save the service instance to the repo", () -> {
                             ArgumentCaptor<ServiceInstance> instCap =
@@ -122,7 +122,7 @@ public class EcsServiceInstanceServiceTest {
                             });
 
                             It("should not create a bucket", () -> verify(ecs, times(0))
-                                    .createBucket(any(), any(), any(), any()));
+                                    .createBucket(any(), any(), any(), any(), any()));
 
                             It("should save the original & remote service instances to the repo", () -> {
                                 ArgumentCaptor<ServiceInstance> instCap =

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceServiceTest.java
@@ -231,7 +231,7 @@ public class EcsServiceInstanceServiceTest {
                         });
 
                         It("should find the service instance in the repo", () ->
-                                verify(repo, times(1))
+                                verify(repo, times(2))
                                         .find(BUCKET_NAME));
 
                         It("should not delete the service instance from the repo", () ->

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceServiceTest.java
@@ -5,6 +5,7 @@ import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
 import com.github.paulcwarren.ginkgo4j.Ginkgo4jRunner;
+import com.google.errorprone.annotations.Var;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
@@ -455,15 +456,15 @@ public class EcsServiceInstanceServiceTest {
                     Context(BASIC_SERVICE, () -> {
                         BeforeEach(() -> {
                             ServiceInstance inst =
-                                    new ServiceInstance(namespaceCreateRequestFixture(params));
-                            when(repo.find(NAMESPACE))
+                                    new ServiceInstance(namespaceCreateRequestFixture(SERVICE_INSTANCE_ID, params));
+                            when(repo.find(SERVICE_INSTANCE_ID))
                                     .thenReturn(inst);
-                            instSvc.deleteServiceInstance(namespaceDeleteRequestFixture());
+                            instSvc.deleteServiceInstance(namespaceDeleteRequestFixture(inst.getServiceInstanceId()));
                         });
 
                         It("should delete the namespace", () ->
                                 verify(ecs, times(1))
-                                        .deleteNamespace(NAMESPACE));
+                                        .deleteNamespace(SERVICE_INSTANCE_ID));
                     });
 
                     Context(WITH_REMOTE_CONNECTION, () -> {

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceServiceTest.java
@@ -513,34 +513,34 @@ public class EcsServiceInstanceServiceTest {
                 Context("#updateServiceInstance", () -> {
                     Context(BASIC_SERVICE, () -> {
                         BeforeEach(() -> {
-                            when(repo.find(NAMESPACE))
+                            when(repo.find(SERVICE_INSTANCE_ID))
                                     .thenReturn(new ServiceInstance(namespaceCreateRequestFixture(params)));
-                            when(ecs.changeNamespacePlan(NAMESPACE, serviceDef, plan, params))
+                            when(ecs.changeNamespacePlan(SERVICE_INSTANCE_ID, serviceDef, plan, params))
                                     .thenReturn(settings);
                             instSvc.updateServiceInstance(namespaceUpdateRequestFixture(params));
                         });
 
                         It("should find the service instance in the repo", () ->
-                                verify(repo, times(1))
-                                        .find(NAMESPACE));
+                                verify(repo, times(2))
+                                        .find(SERVICE_INSTANCE_ID));
 
                         It("should not delete the service instance from the repo", () ->
                                 verify(repo, times(0))
-                                        .delete(NAMESPACE));
+                                        .delete(SERVICE_INSTANCE_ID));
 
                         It("should save the updated service instance to the repo", () -> {
                             ArgumentCaptor<ServiceInstance> instCap =
                                     ArgumentCaptor.forClass(ServiceInstance.class);
                             verify(repo, times(1))
                                     .save(instCap.capture());
-                            assertEquals(NAMESPACE, instCap.getValue().getServiceInstanceId());
+                            assertEquals(SERVICE_INSTANCE_ID, instCap.getValue().getServiceInstanceId());
                             assertEquals("namespace",
                                     instCap.getValue().getServiceSettings().get("service-type"));
                         });
 
                         It("should update the namespace", () ->
                                 verify(ecs, times(1))
-                                        .changeNamespacePlan(NAMESPACE, serviceDef, plan, params));
+                                        .changeNamespacePlan(SERVICE_INSTANCE_ID, serviceDef, plan, params));
 
                     });
 
@@ -549,7 +549,7 @@ public class EcsServiceInstanceServiceTest {
                             ServiceInstance inst =
                                     new ServiceInstance(namespaceCreateRequestFixture(params));
                             inst.addReference(SERVICE_INSTANCE_ID);
-                            when(repo.find(NAMESPACE))
+                            when(repo.find(SERVICE_INSTANCE_ID))
                                     .thenReturn(inst);
                         });
 
@@ -566,7 +566,7 @@ public class EcsServiceInstanceServiceTest {
                     Context("with remote connection parameters", () -> {
                         BeforeEach(() -> {
                             ServiceInstance inst = new ServiceInstance(namespaceCreateRequestFixture(params));
-                            when(repo.find(NAMESPACE))
+                            when(repo.find(SERVICE_INSTANCE_ID))
                                     .thenReturn(inst);
                         });
 

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceTest.java
@@ -199,7 +199,7 @@ public class EcsServiceTest {
         PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
 
         Map<String, Object> params = new HashMap<>();
-        Map<String, Object> serviceSettings = ecs.createBucket(BUCKET_NAME, service, plan, params);
+        Map<String, Object> serviceSettings = ecs.createBucket(BUCKET_NAME, BUCKET_NAME, service, plan, params);
 
         Map<String, Integer> quota = (Map<String, Integer>) serviceSettings.get("quota");
         assertEquals(4, quota.get(WARN).longValue());
@@ -238,7 +238,7 @@ public class EcsServiceTest {
                 .thenReturn(service);
 
         Map<String, Object> serviceSettings =
-                ecs.createBucket(BUCKET_NAME, service, plan, new HashMap<>());
+                ecs.createBucket(BUCKET_NAME,  BUCKET_NAME, service, plan, new HashMap<>());
         assertTrue((Boolean) serviceSettings.get(ENCRYPTED));
         assertTrue((Boolean) serviceSettings.get(ACCESS_DURING_OUTAGE));
         assertTrue((Boolean) serviceSettings.get(FILE_ACCESSIBLE));
@@ -278,7 +278,7 @@ public class EcsServiceTest {
         ServiceDefinitionProxy service = bucketServiceFixture();
         PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
 
-        Map<String, Object> serviceSettings = ecs.createBucket(BUCKET_NAME, service, plan, params);
+        Map<String, Object> serviceSettings = ecs.createBucket(BUCKET_NAME, BUCKET_NAME, service, plan, params);
         Map<String, Integer> returnQuota = (Map<String, Integer>) serviceSettings.get(QUOTA);
         assertEquals(4, returnQuota.get(WARN).longValue());
         assertEquals(5, returnQuota.get(LIMIT).longValue());
@@ -908,7 +908,7 @@ public class EcsServiceTest {
         when(catalog.findServiceDefinition(NAMESPACE_SERVICE_ID))
                 .thenReturn(namespaceServiceFixture());
 
-        Map<String, Object> serviceSettings = ecs.createBucket(BUCKET_NAME, service, plan, params);
+        Map<String, Object> serviceSettings = ecs.createBucket(BUCKET_NAME, BUCKET_NAME, service, plan, params);
         assertEquals(THIRTY_DAYS_IN_SEC, serviceSettings.get(DEFAULT_RETENTION));
 
         PowerMockito.verifyStatic(BucketRetentionAction.class);

--- a/src/test/java/com/emc/ecs/servicebroker/service/ReclaimPolicyTests.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/ReclaimPolicyTests.java
@@ -161,7 +161,7 @@ public class ReclaimPolicyTests {
         plan.setServiceSettings(new HashMap<>());
 
         Map<String, Object> params = new HashMap<>();
-        ecs.createBucket(BUCKET_NAME, service, plan, params);
+        ecs.createBucket(SERVICE_INSTANCE_ID, BUCKET_NAME, service, plan, params);
     }
 
     @Test
@@ -178,15 +178,15 @@ public class ReclaimPolicyTests {
 
         params.put(ALLOWED_RECLAIM_POLICIES, "Delete, Detach");
         params.put(RECLAIM_POLICY, ReclaimPolicy.Delete);
-        ecs.createBucket(BUCKET_NAME, service, plan, params);
+        ecs.createBucket(SERVICE_INSTANCE_ID, BUCKET_NAME, service, plan, params);
 
         params.put(ALLOWED_RECLAIM_POLICIES, "Detach,Fail");
         params.put(RECLAIM_POLICY, ReclaimPolicy.Fail);
-        ecs.createBucket(BUCKET_NAME, service, plan, params);
+        ecs.createBucket(SERVICE_INSTANCE_ID, BUCKET_NAME, service, plan, params);
 
         params.put(ALLOWED_RECLAIM_POLICIES, "Delete, Detach");
         params.put(RECLAIM_POLICY, ReclaimPolicy.Detach);
-        ecs.createBucket(BUCKET_NAME, service, plan, params);
+        ecs.createBucket(SERVICE_INSTANCE_ID, BUCKET_NAME, service, plan, params);
     }
 
     @Test
@@ -201,7 +201,7 @@ public class ReclaimPolicyTests {
         try {
             service.getServiceSettings().put(ALLOWED_RECLAIM_POLICIES, "Detach");
             params.put(RECLAIM_POLICY, ReclaimPolicy.Delete);
-            ecs.createBucket(BUCKET_NAME, service, plan, params);
+            ecs.createBucket(SERVICE_INSTANCE_ID, BUCKET_NAME, service, plan, params);
             fail("Expected Exception");
         }catch(Exception ignore) {
         }
@@ -209,7 +209,7 @@ public class ReclaimPolicyTests {
         try {
             service.getServiceSettings().put(ALLOWED_RECLAIM_POLICIES, "Delete");
             params.put(RECLAIM_POLICY, ReclaimPolicy.Fail);
-            ecs.createBucket(BUCKET_NAME, service, plan, params);
+            ecs.createBucket(SERVICE_INSTANCE_ID, BUCKET_NAME, service, plan, params);
             fail("Expected Exception");
         }catch(Exception ignore) {
         }
@@ -217,7 +217,7 @@ public class ReclaimPolicyTests {
         try {
             service.getServiceSettings().put(ALLOWED_RECLAIM_POLICIES, "Fail");
             params.put(RECLAIM_POLICY, ReclaimPolicy.Detach);
-            ecs.createBucket(BUCKET_NAME, service, plan, params);
+            ecs.createBucket(SERVICE_INSTANCE_ID, BUCKET_NAME, service, plan, params);
             fail("Expected Exception");
         }catch(Exception ignore) {
         }

--- a/src/test/resources/wiremockS3/mappings/s3-delete-binding-cf2f8326-3465-4810-9da1-54d328935b81.json
+++ b/src/test/resources/wiremockS3/mappings/s3-delete-binding-cf2f8326-3465-4810-9da1-54d328935b81.json
@@ -1,0 +1,21 @@
+{
+	"scenarioName": "binding-cf2f8326-3465-4810-9da1-54d328935b81",
+	"requiredScenarioState": "Created",
+	"newScenarioState": "Started",
+    "request": {
+        "method": "DELETE",
+        "url": "/ecs-cf-broker-repository/service-instance-binding/cf2f8326-3465-4810-9da1-54d328935b81.json",
+        "headers": {
+        	"Authorization" : {
+        		"matches": "AWS ecs-cf-broker-user:.*"
+        	}
+        }
+    },
+    "response": {
+        "status": "204",
+        "headers": {
+			"x-amz-request-id": "0a05881f:150a5d74db8:1b23:4",
+			"x-amz-id-2": "9edc6c7b2841f4facfc63af0f50256253fa46e1ec24cc03172f28660fa13efe3"
+		}
+    }
+}

--- a/src/test/resources/wiremockS3/mappings/s3-get-binding-cf2f8326-3465-4810-9da1-54d328935b81.json
+++ b/src/test/resources/wiremockS3/mappings/s3-get-binding-cf2f8326-3465-4810-9da1-54d328935b81.json
@@ -1,0 +1,25 @@
+{
+  "scenarioName": "binding-cf2f8326-3465-4810-9da1-54d328935b81",
+  "requiredScenarioState": "Created",
+  "request": {
+    "method": "GET",
+    "url": "/ecs-cf-broker-repository/service-instance-binding/cf2f8326-3465-4810-9da1-54d328935b81.json",
+    "headers": {
+      "Authorization" : {
+        "matches": "AWS ecs-cf-broker-user:.*"
+      }
+    }
+  },
+  "response": {
+    "status": "200",
+    "headers": {
+      "x-amz-request-id": "0a05881f:150a5d74db8:1b23:0",
+      "x-amz-id-2": "9edc6c7b2841f4facfc63af0f50256253fa46e1ec24cc03172f28660fa13efe3",
+      "ETag": "\"f9b585d21982a02a25527705d66bd6d6\"",
+      "x-emc-mtime": "1450675293828",
+      "Content-Encoding": "identity",
+      "Content-Type": "application/octet-stream"
+    },
+    "body": "{\"name\":\"cf2f8326-3465-4810-9da1-54d328935b81\",\"binding_id\":\"cf2f8326-3465-4810-9da1-54d328935b81\",\"service_id\":\"service-one-id\",\"plan_id\":\"plan-one-id\",\"bind_resource\":{\"app_guid\":\"app-guid\",\"route\":null},\"parameters\":{\"number\":1234,\"flag\":true,\"text\":\"abcdefg\",\"nested\":{\"text2\":\"zyxwvu\",\"flag2\":true,\"number2\":9876}},\"credentials\":{\"bucket\":\"bucket\",\"endpoint\":\"http://127.0.0.1:9020\",\"secretKey\":\"password\",\"accessKey\":\"user\"}}"
+  }
+}

--- a/src/test/resources/wiremockS3/mappings/s3-put-binding-cf2f8326-3465-4810-9da1-54d328935b81.json
+++ b/src/test/resources/wiremockS3/mappings/s3-put-binding-cf2f8326-3465-4810-9da1-54d328935b81.json
@@ -1,0 +1,30 @@
+{
+	"scenarioName": "binding-cf2f8326-3465-4810-9da1-54d328935b81",
+	"requiredScenarioState": "Started",
+	"newScenarioState": "Created",
+    "request": {
+        "method": "PUT",
+        "url": "/ecs-cf-broker-repository/service-instance-binding/cf2f8326-3465-4810-9da1-54d328935b81.json",
+        "headers": {
+        	"Content-Type": {
+        		"equalTo": "application/octet-stream"
+        	},
+        	"Authorization" : {
+        		"matches": "AWS ecs-cf-broker-user:.*"
+        	}
+        },
+        "bodyPatterns": [
+        	{
+        		"equalToJson": "{\"name\":\"cf2f8326-3465-4810-9da1-54d328935b81\",\"binding_id\":\"cf2f8326-3465-4810-9da1-54d328935b81\",\"service_id\":\"service-one-id\",\"plan_id\":\"plan-one-id\",\"bind_resource\":{\"app_guid\":\"app-guid\",\"route\":null},\"parameters\":{\"number\":1234,\"flag\":true,\"text\":\"abcdefg\",\"nested\":{\"text2\":\"zyxwvu\",\"flag2\":true,\"number2\":9876}},\"credentials\":{\"bucket\":\"bucket\",\"endpoint\":\"http://127.0.0.1:9020\",\"secretKey\":\"password\",\"accessKey\":\"user\"}}"
+        	}
+        ]
+    },
+    "response": {
+        "status": "200",
+        "headers": {
+			"x-amz-request-id": "0a05881f:150a5d74db8:1b1f:0",
+			"x-amz-id-2": "9edc6c7b2841f4facfc63af0f50256253fa46e1ec24cc03172f28660fa13efe3",
+			"x-emc-mtime": "1450675293828"
+		}
+    }
+}


### PR DESCRIPTION
This PR introduces a new parameter called `name` that can be passed with an Instance or Binding Creation to provide a hint to the Broker as to how to name the provisioned artifact (bucket, namespaces, user etc).

If `name` is provided the generated name will be of the format `<prefix>-<name>-<id>` and if the `name` isn't provided the name will be of the format `<prefix>-<id>` as it currently is.  This means the change is backwards compatible and only take effect if a `name` is passed.

**How It Works**
If works by setting the ServiceInstance or ServiceInstanceBinding name correctly during correctly during construction by checking the provided parameters.  

Unfortunately code (and also tests) assumed that the `name` would always be a `SERVICE_INSTANCE_ID` or `BINDING_ID` and took short cuts.  With this change the `.getName` should be considered the source of truth for the name.  And component requiring the name should in future use the `.getName` of the instance or binding instead of making any assumptions on the name.

**Notes**
The Binding workflow needed to be more heavily refactored than I would really like since it always assumed the name would be the `BindingID`.  To get around this the ECS Service now looks up the binding and passes it into the workflow.  Binding workflow operations can then use this context as the source of truth about the binding. 

This is different to how the Instance workflow works and certainly there could be further work in future to make both workflows consistent however, at present I decided not to perform such refactoring in order to reduce the number of code changes.