### PR TITLE
Update Dockerfile to correctly build final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
 FROM gradle:4.10-jdk8 as GradleBuilder
 
-COPY --chown=gradle:gradle build.gradle /home/gradle/src/build.gradle
-COPY --chown=gradle:gradle src /home/gradle/src/src
+COPY --chown=gradle:gradle build.gradle /home/gradle/src/ecs-cf-service-broker/build.gradle
+COPY --chown=gradle:gradle src /home/gradle/src/ecs-cf-service-broker/src
 
-WORKDIR /home/gradle/src
+WORKDIR /home/gradle/src/ecs-cf-service-broker
 
 ENV GRADLE_USER_HOME=/home/gradle
 
-
-RUN gradle clean assemble  --stacktrace
+RUN gradle clean assemble
 
 # =====================================================================================
 FROM openjdk:8-jdk-alpine
 VOLUME /tmp
-COPY --from=GradleBuilder /home/gradle/src/build/libs/ecs-cf-service-broker-*.jar app.jar
+COPY --from=GradleBuilder /home/gradle/src/ecs-cf-service-broker/build/libs/ecs-cf-service-broker*.jar app.jar


### PR DESCRIPTION
The Dockerfile originally submitted appears to sometimes fail, this updates the Dockerfile to always work.

**Testing**

_Building with NO cache_
```
$ docker build --no-cache .
Sending build context to Docker daemon  59.85MB
Step 1/9 : FROM gradle:4.10-jdk8 as GradleBuilder
 ---> 8b87b032dac3
Step 2/9 : COPY --chown=gradle:gradle build.gradle /home/gradle/src/ecs-cf-service-broker/build.gradle
 ---> 3b536087c510
Step 3/9 : COPY --chown=gradle:gradle src /home/gradle/src/ecs-cf-service-broker/src
 ---> 7c62bde6ea56
Step 4/9 : WORKDIR /home/gradle/src/ecs-cf-service-broker
 ---> Running in a0255e03cb82
Removing intermediate container a0255e03cb82
 ---> bd98e3e6060f
Step 5/9 : ENV GRADLE_USER_HOME=/home/gradle
 ---> Running in 0956b034854f
Removing intermediate container 0956b034854f
 ---> a3dbb58792ce
Step 6/9 : RUN gradle clean assemble
 ---> Running in f5e26023d302

Welcome to Gradle 4.10.3!

Here are the highlights of this release:
 - Incremental Java compilation by default
 - Periodic Gradle caches cleanup
 - Gradle Kotlin DSL 1.0-RC6
 - Nested included builds
 - SNAPSHOT plugin versions in the `plugins {}` block

For more details see https://docs.gradle.org/4.10.3/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)
> Task :clean UP-TO-DATE

> Task :compileJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :processResources
> Task :classes
> Task :findMainClass
> Task :jar
> Task :bootRepackage
> Task :assemble

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 40s
6 actionable tasks: 5 executed, 1 up-to-date
Removing intermediate container f5e26023d302
 ---> 1e08d01e6425
Step 7/9 : FROM openjdk:8-jdk-alpine
 ---> a3562aa0b991
Step 8/9 : VOLUME /tmp
 ---> Running in 78a034927b84
Removing intermediate container 78a034927b84
 ---> c0508b6bc0ec
Step 9/9 : COPY --from=GradleBuilder /home/gradle/src/ecs-cf-service-broker/build/libs/ecs-cf-service-broker*.jar app.jar
 ---> 3dfb2ca49364
Successfully built 3dfb2ca49364
```

_Running Image:_
```
$ docker run -it 3dfb2ca49364 java -jar app.jar

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::       (v1.5.21.RELEASE)

2020-04-09 12:40:30.274  INFO 1 --- [           main] c.e.e.c.broker.config.Application        : Starting Application on 25f1362ff279 with PID 1 (/app.jar started by root in /)
2020-04-09 12:40:30.277  INFO 1 --- [           main] c.e.e.c.broker.config.Application        : No active profile set, falling back to default profiles: default
2020-04-09 12:40:30.349  INFO 1 --- [           main] ationConfigEmbeddedWebApplicationContext : Refreshing org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext@63c12fb0: startup date [Thu Apr 09 12:40:30 GMT 2020]; root of context hierarchy
2020-04-09 12:40:31.291  INFO 1 --- [           main] f.a.AutowiredAnnotationBeanPostProcessor : JSR-330 'javax.inject.Inject' annotation found and supported for autowiring
2020-04-09 12:40:31.624  INFO 1 --- [           main] s.b.c.e.t.TomcatEmbeddedServletContainer : Tomcat initialized with port(s): 8080 (http)
^C2020-04-09 12:40:31.660  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2020-04-09 12:40:31.660  INFO 1 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet Engine: Apache Tomcat/8.5.40
...
...
...
```


Signed-off-by: David Maddison <david.maddison@dell.com>