### PR TITLE
Add support for Reclaim Policy and Bucket-Wipe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
         exclude module: "slf4j-log4j12"
     }
     compile(group: 'com.google.guava', name: 'guava', version: '28.2-jre')
+    compile(group: 'com.emc.ecs', name: 'bucket-wipe', version: '2.0.0') {
+        exclude module: "slf4j-log4j12"
+    }
 
     testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion)
     testCompile(group: 'junit', name: 'junit', version: '4.13')

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -71,7 +71,6 @@ data:
           access-during-outage: true
           head-type: s3
           service-type: bucket
-          allowed-reclaim-policies: Fail, Detach, Delete
         tags:
         - s3
         - bucket

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -14,6 +14,7 @@ data:
   {{- if .Values.certificate }}
       certificate: {{ toYaml .Values.certificate | indent 6 }}
   {{- end }}
+      defaultReclaimPolicy: {{ .Values.defaultReclaimPolicy }}
     catalog:
       services:
       -
@@ -70,6 +71,7 @@ data:
           access-during-outage: true
           head-type: s3
           service-type: bucket
+          allowed-reclaim-policies: Fail, Detach, Delete
         tags:
         - s3
         - bucket

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -8,14 +8,23 @@ namespace: "131118670375936839"
 prefix: "kubetesting-"
 replicationGroup: "ecstestdrivegeo"
 
+# Management SSL Custom CA Trust Certificate
 certificate: |-
 
+# ECS Object API
 api:
   name: ecs-broker
   namespace: default
   endpoint: "https://object.ecstestdrive.com"
   username: admin
   password: ChangeMe
+
+# ECS Management Endpoint
+ecsConnection:
+  name: ecs-broker-connection
+  endpoint: "https://portal.ecstestdrive.com"
+  username: <MANAGEMENT_USER>
+  password: <PASSWORD>
 
 image:
   repository: emccorp/ecs-service-broker

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -8,23 +8,14 @@ namespace: "131118670375936839"
 prefix: "kubetesting-"
 replicationGroup: "ecstestdrivegeo"
 
-# Management SSL Custom CA Trust Certificate
 certificate: |-
 
-# ECS Object API
 api:
   name: ecs-broker
   namespace: default
   endpoint: "https://object.ecstestdrive.com"
   username: admin
   password: ChangeMe
-
-# ECS Management Endpoint
-ecsConnection:
-  name: ecs-broker-connection
-  endpoint: "https://portal.ecstestdrive.com"
-  username: <MANAGEMENT_USER>
-  password: <PASSWORD>
 
 image:
   repository: emccorp/ecs-service-broker
@@ -70,6 +61,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# The default ReclaimPolicy to use if one has not been explicitly specified (valid values are Fail, Detach, Delete)
+defaultReclaimPolicy: Fail
 
 # Indicates this should be registered as a ServiceCatalog Broker
 serviceCatalog: false

--- a/src/main/java/com/emc/ecs/servicebroker/config/Application.java
+++ b/src/main/java/com/emc/ecs/servicebroker/config/Application.java
@@ -4,6 +4,7 @@ import com.emc.ecs.servicebroker.EcsManagementClientException;
 import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceBindingRepository;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
+import com.emc.ecs.servicebroker.repository.BucketWipeFactory;
 import com.emc.ecs.servicebroker.service.EcsService;
 import com.emc.ecs.servicebroker.service.EcsServiceInstanceBindingService;
 import com.emc.ecs.servicebroker.service.EcsServiceInstanceService;
@@ -89,6 +90,11 @@ public class Application {
     @Bean
     public ServiceInstanceBindingRepository serviceInstanceBindingRepository() {
         return new ServiceInstanceBindingRepository();
+    }
+
+    @Bean
+    public BucketWipeFactory bucketWipeFactory() {
+        return new BucketWipeFactory();
     }
 
     private static String[] getArgs() {

--- a/src/main/java/com/emc/ecs/servicebroker/config/BrokerConfig.java
+++ b/src/main/java/com/emc/ecs/servicebroker/config/BrokerConfig.java
@@ -1,5 +1,6 @@
 package com.emc.ecs.servicebroker.config;
 
+import com.emc.ecs.servicebroker.model.ReclaimPolicy;
 import com.emc.ecs.servicebroker.model.TileSelector;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +30,7 @@ public class BrokerConfig {
     private String prefix = "ecs-cf-broker-";
     private String brokerApiVersion = "*";
     private String certificate;
+    private String defaultReclaimPolicy = ReclaimPolicy.Fail.name();
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -205,4 +207,11 @@ public class BrokerConfig {
         this.repositoryPlanId = repositoryPlanId;
     }
 
+    public String getDefaultReclaimPolicy() {
+        return defaultReclaimPolicy;
+    }
+
+    public void setDefaultReclaimPolicy(String defaultReclaimPolicy) {
+        this.defaultReclaimPolicy = defaultReclaimPolicy;
+    }
 }

--- a/src/main/java/com/emc/ecs/servicebroker/model/ReclaimPolicy.java
+++ b/src/main/java/com/emc/ecs/servicebroker/model/ReclaimPolicy.java
@@ -13,6 +13,8 @@ public enum ReclaimPolicy {
     // Delete all Objects before deleting the bucket
     Delete;
 
+    public static ReclaimPolicy DEFAULT_RECLAIM_POLICY = Fail;
+
     private static String RECLAIM_POLICY = "reclaim-policy";
     private static String ALLOWED_RECLAIM_POLICIES = "allowed-reclaim-policies";
 
@@ -23,8 +25,8 @@ public enum ReclaimPolicy {
             return ReclaimPolicy.valueOf(reclaimPolicy);
         }
 
-        // No Reclaim Policy, Fail is the default
-        return ReclaimPolicy.Fail;
+        // No Explict ReclaimPolicy specified
+        return DEFAULT_RECLAIM_POLICY;
     }
 
     public static List<ReclaimPolicy> getAllowedReclaimPolicies(Map<String, Object> params) {
@@ -38,8 +40,8 @@ public enum ReclaimPolicy {
             return allowedPolicies;
         }
 
-        // If nothing specified then default to only allowing Fail
-        return Collections.singletonList(Fail);
+        // No explicit Allowed Reclaim Policies Specified
+        return Collections.singletonList(DEFAULT_RECLAIM_POLICY);
     }
 
     public static boolean isPolicyAllowed(Map<String, Object> params) {

--- a/src/main/java/com/emc/ecs/servicebroker/model/ReclaimPolicy.java
+++ b/src/main/java/com/emc/ecs/servicebroker/model/ReclaimPolicy.java
@@ -1,0 +1,48 @@
+package com.emc.ecs.servicebroker.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public enum ReclaimPolicy {
+    // Attempt to delete but fail if the bucket isn't empty
+    Fail,
+    // Leave bucket in-tact but remove from repository
+    Detach,
+    // Delete all Objects before deleting the bucket
+    Delete;
+
+    private static String RECLAIM_POLICY = "reclaim-policy";
+    private static String ALLOWED_RECLAIM_POLICIES = "allowed-reclaim-policies";
+
+    public static ReclaimPolicy getReclaimPolicy(Map<String, Object> params) {
+        if (params.containsKey(RECLAIM_POLICY)) {
+            String reclaimPolicy = params.getOrDefault(RECLAIM_POLICY, ReclaimPolicy.Delete).toString();
+
+            return ReclaimPolicy.valueOf(reclaimPolicy);
+        }
+
+        // No Reclaim Policy, Fail is the default
+        return ReclaimPolicy.Fail;
+    }
+
+    public static List<ReclaimPolicy> getAllowedReclaimPolicies(Map<String, Object> params) {
+        if (params.containsKey(ALLOWED_RECLAIM_POLICIES)) {
+            List<ReclaimPolicy> allowedPolicies = new ArrayList<>();
+
+            for (String reclaimPolicy : params.get(ALLOWED_RECLAIM_POLICIES).toString().split(",")) {
+                allowedPolicies.add(ReclaimPolicy.valueOf(reclaimPolicy.trim()));
+            }
+
+            return allowedPolicies;
+        }
+
+        // If nothing specified then default to only allowing Fail
+        return Collections.singletonList(Fail);
+    }
+
+    public static boolean isPolicyAllowed(Map<String, Object> params) {
+        return getAllowedReclaimPolicies(params).contains(getReclaimPolicy(params));
+    }
+}

--- a/src/main/java/com/emc/ecs/servicebroker/model/ReclaimPolicy.java
+++ b/src/main/java/com/emc/ecs/servicebroker/model/ReclaimPolicy.java
@@ -17,7 +17,7 @@ public enum ReclaimPolicy {
     private static String ALLOWED_RECLAIM_POLICIES = "allowed-reclaim-policies";
 
     public static ReclaimPolicy getReclaimPolicy(Map<String, Object> params) {
-        if (params.containsKey(RECLAIM_POLICY)) {
+        if (params != null && params.containsKey(RECLAIM_POLICY)) {
             String reclaimPolicy = params.getOrDefault(RECLAIM_POLICY, ReclaimPolicy.Delete).toString();
 
             return ReclaimPolicy.valueOf(reclaimPolicy);
@@ -28,7 +28,7 @@ public enum ReclaimPolicy {
     }
 
     public static List<ReclaimPolicy> getAllowedReclaimPolicies(Map<String, Object> params) {
-        if (params.containsKey(ALLOWED_RECLAIM_POLICIES)) {
+        if (params != null && params.containsKey(ALLOWED_RECLAIM_POLICIES)) {
             List<ReclaimPolicy> allowedPolicies = new ArrayList<>();
 
             for (String reclaimPolicy : params.get(ALLOWED_RECLAIM_POLICIES).toString().split(",")) {

--- a/src/main/java/com/emc/ecs/servicebroker/repository/BucketWipeFactory.java
+++ b/src/main/java/com/emc/ecs/servicebroker/repository/BucketWipeFactory.java
@@ -1,0 +1,23 @@
+package com.emc.ecs.servicebroker.repository;
+
+import com.emc.ecs.servicebroker.config.BrokerConfig;
+import com.emc.ecs.tool.BucketWipeOperations;
+import com.emc.object.s3.S3Config;
+import com.emc.object.s3.jersey.S3JerseyClient;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Used to create instances of the BucketWipeOperations based on a given broker config
+ */
+public class BucketWipeFactory {
+
+    public BucketWipeOperations getBucketWipe(BrokerConfig broker) throws URISyntaxException {
+        S3Config s3Config = new S3Config(new URI(broker.getRepositoryEndpoint()));
+        s3Config.withIdentity(broker.getPrefixedUserName())
+            .withSecretKey(broker.getRepositorySecret());
+
+        return new BucketWipeOperations(new S3JerseyClient(s3Config));
+    }
+}

--- a/src/main/java/com/emc/ecs/servicebroker/repository/BucketWipeFactory.java
+++ b/src/main/java/com/emc/ecs/servicebroker/repository/BucketWipeFactory.java
@@ -2,6 +2,7 @@ package com.emc.ecs.servicebroker.repository;
 
 import com.emc.ecs.servicebroker.config.BrokerConfig;
 import com.emc.ecs.tool.BucketWipeOperations;
+import com.emc.ecs.tool.BucketWipeResult;
 import com.emc.object.s3.S3Config;
 import com.emc.object.s3.jersey.S3JerseyClient;
 
@@ -19,5 +20,9 @@ public class BucketWipeFactory {
             .withSecretKey(broker.getRepositorySecret());
 
         return new BucketWipeOperations(new S3JerseyClient(s3Config));
+    }
+
+    public BucketWipeResult newBucketWipeResult() {
+        return new BucketWipeResult();
     }
 }

--- a/src/main/java/com/emc/ecs/servicebroker/repository/LastOperationSerializer.java
+++ b/src/main/java/com/emc/ecs/servicebroker/repository/LastOperationSerializer.java
@@ -22,7 +22,7 @@ public class LastOperationSerializer {
         super();
     }
 
-    LastOperationSerializer(final OperationState operationState,
+    public LastOperationSerializer(final OperationState operationState,
             final String description, final boolean deleteOperation) {
         super();
         this.setOperationState(operationState);

--- a/src/main/java/com/emc/ecs/servicebroker/repository/ServiceInstance.java
+++ b/src/main/java/com/emc/ecs/servicebroker/repository/ServiceInstance.java
@@ -1,5 +1,6 @@
 package com.emc.ecs.servicebroker.repository;
 
+import com.emc.ecs.servicebroker.model.ReclaimPolicy;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -120,6 +121,14 @@ public class ServiceInstance {
         return references;
     }
 
+    public LastOperationSerializer getLastOperation() {
+        return lastOperation;
+    }
+
+    public void setLastOperation(LastOperationSerializer lastOperation) {
+        this.lastOperation = lastOperation;
+    }
+
     public boolean isAsync() {
         return async;
     }
@@ -190,5 +199,4 @@ public class ServiceInstance {
     public void setServiceSettings(Map<String, Object> serviceSettings) {
         this.serviceSettings = serviceSettings;
     }
-
 }

--- a/src/main/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflow.java
@@ -41,7 +41,8 @@ public class BucketInstanceWorkflow extends InstanceWorkflowImpl {
                 switch(reclaimPolicy) {
                     case Fail:
                         logger.info("Reclaim Policy is {} for bucket {}, attempting to delete bucket", reclaimPolicy, ecs.prefix(instance.getName()));
-                        return ecs.deleteBucket(id);
+                        ecs.deleteBucket(id);
+                        return null;
                     case Detach:
                         logger.info("Reclaim Policy is {} for bucket {}, Not Deleting Bucket", reclaimPolicy, ecs.prefix(instance.getName()));
                         return null;

--- a/src/main/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflow.java
@@ -2,16 +2,22 @@ package com.emc.ecs.servicebroker.service;
 
 import com.emc.ecs.servicebroker.model.PlanProxy;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
+import com.emc.ecs.servicebroker.model.ReclaimPolicy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class BucketInstanceWorkflow extends InstanceWorkflowImpl {
+    private static final Logger logger = LoggerFactory.getLogger(BucketInstanceWorkflow.class);
+
     BucketInstanceWorkflow(ServiceInstanceRepository repo, EcsService ecs) {
         super(repo, ecs);
     }
@@ -22,13 +28,29 @@ public class BucketInstanceWorkflow extends InstanceWorkflowImpl {
     }
 
     @Override
-    public void delete(String id) {
+    public CompletableFuture delete(String id) {
         try {
             ServiceInstance instance = instanceRepository.find(id);
             if (instance.getReferences().size() > 1) {
                 removeInstanceFromReferences(instance, id);
+
+                return null;
             } else {
-                ecs.deleteBucket(id);
+                ReclaimPolicy reclaimPolicy = ReclaimPolicy.getReclaimPolicy(instance.getServiceSettings());
+
+                switch(reclaimPolicy) {
+                    case Fail:
+                        logger.info("Reclaim Policy is {} for bucket {}, attempting to delete bucket", reclaimPolicy, ecs.prefix(instance.getName()));
+                        return ecs.deleteBucket(id);
+                    case Detach:
+                        logger.info("Reclaim Policy is {} for bucket {}, Not Deleting Bucket", reclaimPolicy, ecs.prefix(instance.getName()));
+                        return null;
+                    case Delete:
+                        logger.info("Reclaim Policy is {} for bucket {}, Wiping and Deleting bucket", reclaimPolicy, ecs.prefix(instance.getName()));
+                        return ecs.wipeAndDeleteBucket(id);
+                    default:
+                        throw new ServiceBrokerException("ReclaimPolicy "+reclaimPolicy+" not supported");
+                }
             }
         } catch (IOException e) {
             throw new ServiceBrokerException(e);

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -71,6 +71,7 @@ public class EcsService {
         try {
             lookupObjectEndpoints();
             lookupReplicationGroupID();
+            prepareDefaultReclaimPolicy();
             prepareRepository();
             prepareBucketWipe();
         } catch (EcsManagementClientException e) {
@@ -383,6 +384,11 @@ public class EcsService {
 
     private void prepareBucketWipe() throws URISyntaxException {
         bucketWipe = bucketWipeFactory.getBucketWipe(broker);
+    }
+
+    private void prepareDefaultReclaimPolicy() {
+        ReclaimPolicy.DEFAULT_RECLAIM_POLICY = ReclaimPolicy.valueOf(broker.getDefaultReclaimPolicy());
+        logger.info("Default Reclaim Policy: "+ReclaimPolicy.DEFAULT_RECLAIM_POLICY);
     }
 
     private String getUserSecret(String id)

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -476,7 +476,7 @@ public class EcsService {
             logger.error("BucketWipe FAILED, deleted {} objects. Leaving bucket {}", result.getDeletedObjects(), prefix(id));
             result.getErrors().forEach(error -> logger.error("BucketWipe {} error: {}", prefix(id), error));
 
-            throw new RuntimeException("BucketWipe Failed for instance " + id);
+            throw new RuntimeException("BucketWipe Failed with "+result.getErrors().size()+" errors: "+result.getErrors().get(0));
         }
 
         // Wipe Succeeded, Attempt Bucket Delete
@@ -485,7 +485,7 @@ public class EcsService {
             BucketAction.delete(connection, prefix(id), broker.getNamespace());
         } catch (EcsManagementClientException e) {
             logger.error("Error deleting bucket "+prefix(id), e);
-            throw new RuntimeException("Error Deleting Bucket "+prefix(id));
+            throw new RuntimeException("Error Deleting Bucket "+prefix(id)+" "+e.getMessage());
         }
     }
 

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -8,10 +8,9 @@ import com.emc.ecs.servicebroker.config.CatalogConfig;
 import com.emc.ecs.servicebroker.model.PlanProxy;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.model.ReclaimPolicy;
+import com.emc.ecs.servicebroker.repository.BucketWipeFactory;
 import com.emc.ecs.tool.BucketWipeOperations;
 import com.emc.ecs.tool.BucketWipeResult;
-import com.emc.object.s3.S3Config;
-import com.emc.object.s3.jersey.S3JerseyClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +19,6 @@ import org.springframework.cloud.servicebroker.exception.ServiceInstanceExistsEx
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -51,6 +49,9 @@ public class EcsService {
 
     @Autowired
     private CatalogConfig catalog;
+
+    @Autowired
+    private BucketWipeFactory bucketWipeFactory;
 
     private BucketWipeOperations bucketWipe;
 
@@ -389,11 +390,7 @@ public class EcsService {
     }
 
     private void prepareBucketWipe() throws URISyntaxException {
-        S3Config s3Config = new S3Config(new URI(broker.getRepositoryEndpoint()));
-        s3Config.withIdentity(broker.getPrefixedUserName())
-            .withSecretKey(broker.getRepositorySecret());
-
-        bucketWipe = new BucketWipeOperations(new S3JerseyClient(s3Config));
+        bucketWipe = bucketWipeFactory.getBucketWipe(broker);
     }
 
     private String getUserSecret(String id)

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
@@ -164,7 +164,7 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
                     .async(false)
                     .build());
         } catch (ServiceInstanceDoesNotExistException e) {
-            // Rethrow "does not exist" so that it's not caught by the generic casue
+            // Rethrow "does not exist" so that it's not caught by the generic case
             throw e;
         } catch (Exception e) {
             throw new ServiceBrokerException(e);

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
@@ -182,7 +182,7 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
 
             if (lastOperation.getOperationState() != OperationState.IN_PROGRESS) {
                 if (lastOperation.isDeleteOperation()) {
-                    logger.info("Operation for {} completed {}, deleting from repository", instance.getServiceInstanceId(), lastOperation.getOperationState());
+                    logger.info("Operation for {} completed, deleting from repository", instance.getServiceInstanceId(), lastOperation.getOperationState());
                     repository.delete(instance.getServiceInstanceId());
                 }
             }

--- a/src/main/java/com/emc/ecs/servicebroker/service/InstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/InstanceWorkflow.java
@@ -12,13 +12,19 @@ import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInsta
 import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public interface InstanceWorkflow {
    InstanceWorkflow withCreateRequest(CreateServiceInstanceRequest request);
    InstanceWorkflow withDeleteRequest(DeleteServiceInstanceRequest request);
    Map<String, Object> changePlan(String id, ServiceDefinitionProxy service, PlanProxy plan,
                                   Map<String, Object> parameters) throws EcsManagementClientException, ServiceBrokerException, IOException;
-   void delete(String id) throws EcsManagementClientException, IOException, ServiceBrokerException;
+
+   /**
+    * Perform the delete operation either async or sync
+    * @return CompetableFuture if the delete is being performed async, otherwise null
+    */
+   CompletableFuture delete(String id) throws EcsManagementClientException, IOException, ServiceBrokerException;
    ServiceInstance create(String id, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters)
            throws EcsManagementClientException, EcsManagementResourceNotFoundException, IOException, JAXBException;
 }

--- a/src/main/java/com/emc/ecs/servicebroker/service/NamespaceInstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/NamespaceInstanceWorkflow.java
@@ -12,6 +12,7 @@ import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class NamespaceInstanceWorkflow extends InstanceWorkflowImpl {
@@ -25,7 +26,7 @@ public class NamespaceInstanceWorkflow extends InstanceWorkflowImpl {
     }
 
     @Override
-    public void delete(String id) {
+    public CompletableFuture delete(String id) {
         try {
             ServiceInstance instance = instanceRepository.find(id);
             if (instance.getReferences().size() > 1) {
@@ -33,6 +34,8 @@ public class NamespaceInstanceWorkflow extends InstanceWorkflowImpl {
             } else {
                 ecs.deleteNamespace(id);
             }
+
+            return null;
         } catch (EcsManagementClientException | JAXBException | IOException e) {
             throw new ServiceBrokerException(e);
         }

--- a/src/main/java/com/emc/ecs/servicebroker/service/RemoteConnectionInstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/RemoteConnectionInstanceWorkflow.java
@@ -14,6 +14,7 @@ import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public class RemoteConnectionInstanceWorkflow extends InstanceWorkflowImpl {
 
@@ -27,7 +28,7 @@ public class RemoteConnectionInstanceWorkflow extends InstanceWorkflowImpl {
     }
 
     @Override
-    public void delete(String id) throws EcsManagementClientException {
+    public CompletableFuture delete(String id) throws EcsManagementClientException {
         throw new ServiceBrokerException("remote_connection parameter invalid for delete operation");
     }
 

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -60,6 +60,8 @@ public class Fixtures {
     private static final String ACCESS_DURING_OUTAGE = "access-during-outage";
     private static final String ENCRYPTED = "encrypted";
     public static final String FILE_ACCESSIBLE = "file-accessible";
+    public static final String RECLAIM_POLICY = "reclaim-policy";
+    public static final String ALLOWED_RECLAIM_POLICIES = "allowed-reclaim-policies";
     private static final String COMPLIANCE_ENABLED = "compliance-enabled";
     private static final String DOMAIN_GROUP_ADMINS = "domain-group-admins";
     public static final String SERVICE_INSTANCE_ID = "service-instance-id";

--- a/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
@@ -89,7 +89,7 @@ public class BucketInstanceWorkflowTest {
                         bucketInstance.setReferences(refs);
                         when(instanceRepo.find(BUCKET_NAME))
                                 .thenReturn(bucketInstance);
-                        doNothing().when(ecs).deleteBucket(BUCKET_NAME);
+                        when(ecs.deleteBucket(BUCKET_NAME)).thenReturn(null);
                     });
 
                     It("should delete the bucket", () -> {

--- a/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/BucketInstanceWorkflowTest.java
@@ -1,6 +1,7 @@
 package com.emc.ecs.servicebroker.service;
 
 import com.emc.ecs.servicebroker.model.PlanProxy;
+import com.emc.ecs.servicebroker.model.ReclaimPolicy;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
@@ -9,10 +10,11 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 import static com.emc.ecs.common.Fixtures.*;
 import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(Ginkgo4jRunner.class)
@@ -33,6 +35,8 @@ public class BucketInstanceWorkflowTest {
                 ecs = mock(EcsService.class);
                 instanceRepo = mock(ServiceInstanceRepository.class);
                 workflow = new BucketInstanceWorkflow(instanceRepo, ecs);
+
+                when(ecs.wipeAndDeleteBucket(any())).thenReturn(CompletableFuture.completedFuture(true));
             });
 
             Context("#changePlan", () -> {
@@ -43,6 +47,56 @@ public class BucketInstanceWorkflowTest {
                     workflow.changePlan(BUCKET_NAME, serviceProxy, planProxy, parameters);
                     verify(ecs, times(1))
                             .changeBucketPlan(BUCKET_NAME, serviceProxy, planProxy, parameters);
+                });
+            });
+
+            Context("#delete with ReclaimPolicy", () -> {
+
+                BeforeEach(() -> {
+                    doNothing().when(instanceRepo).save(any(ServiceInstance.class));
+                    when(instanceRepo.find(BUCKET_NAME)).thenReturn(bucketInstance);
+                });
+
+                Context("with no ReclaimPolicy", () -> {
+                    It("should call delete and NOT wipe bucket", () -> {
+                        CompletableFuture result = workflow.delete(BUCKET_NAME);
+                        assertNull(result);
+                        verify(ecs, times(1)).deleteBucket(BUCKET_NAME);
+                        verify(ecs, times(0)).wipeAndDeleteBucket(BUCKET_NAME);
+                    });
+                });
+
+                Context("with Fail ReclaimPolicy", () -> {
+                    It("should call delete and NOT wipe bucket", () -> {
+                        bucketInstance.setServiceSettings(Collections.singletonMap(RECLAIM_POLICY, ReclaimPolicy.Fail));
+
+                        CompletableFuture result = workflow.delete(BUCKET_NAME);
+                        assertNull(result);
+                        verify(ecs, times(1)).deleteBucket(BUCKET_NAME);
+                        verify(ecs, times(0)).wipeAndDeleteBucket(BUCKET_NAME);
+                    });
+                });
+
+                Context("with Detach ReclaimPolicy", () -> {
+                    It("should not call delete", () -> {
+                        bucketInstance.setServiceSettings(Collections.singletonMap(RECLAIM_POLICY, ReclaimPolicy.Detach));
+
+                        CompletableFuture result = workflow.delete(BUCKET_NAME);
+                        assertNull(result);
+                        verify(ecs, times(0)).deleteBucket(BUCKET_NAME);
+                        verify(ecs, times(0)).wipeAndDeleteBucket(BUCKET_NAME);
+                    });
+                });
+
+                Context("with Delete ReclaimPolicy", () -> {
+                    It("should wipe and delete", () -> {
+                        bucketInstance.setServiceSettings(Collections.singletonMap(RECLAIM_POLICY, ReclaimPolicy.Delete));
+
+                        CompletableFuture result = workflow.delete(BUCKET_NAME);
+                        assertNotNull(result);
+                        verify(ecs, times(0)).deleteBucket(BUCKET_NAME);
+                        verify(ecs, times(1)).wipeAndDeleteBucket(BUCKET_NAME);
+                    });
                 });
             });
 

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceTest.java
@@ -7,6 +7,7 @@ import com.emc.ecs.servicebroker.config.BrokerConfig;
 import com.emc.ecs.servicebroker.config.CatalogConfig;
 import com.emc.ecs.servicebroker.model.PlanProxy;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
+import com.emc.ecs.servicebroker.repository.BucketWipeFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,6 +76,9 @@ public class EcsServiceTest {
     @Mock
     private CatalogConfig catalog;
 
+    @Mock
+    private BucketWipeFactory bucketWipeFactory;
+
     @Autowired
     @InjectMocks
     private EcsService ecs;
@@ -119,7 +123,6 @@ public class EcsServiceTest {
     public void initializeBaseUrlLookup() throws EcsManagementClientException {
         setupInitTest();
         setupBaseUrlTest(BASE_URL_NAME, false);
-        when(broker.getBaseUrl()).thenReturn(BASE_URL_NAME);
 
         ecs.initialize();
         String objEndpoint = HTTP + BASE_URL + _9020;

--- a/src/test/java/com/emc/ecs/servicebroker/service/ReclaimPolicyTests.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/ReclaimPolicyTests.java
@@ -1,0 +1,334 @@
+package com.emc.ecs.servicebroker.service;
+
+import com.emc.ecs.management.sdk.*;
+import com.emc.ecs.management.sdk.model.*;
+import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.config.BrokerConfig;
+import com.emc.ecs.servicebroker.config.CatalogConfig;
+import com.emc.ecs.servicebroker.model.PlanProxy;
+import com.emc.ecs.servicebroker.model.ReclaimPolicy;
+import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
+import com.emc.ecs.servicebroker.repository.BucketWipeFactory;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.emc.ecs.common.Fixtures.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ReplicationGroupAction.class, BucketAction.class,
+    ObjectUserAction.class, ObjectUserSecretAction.class,
+    BaseUrlAction.class, BucketQuotaAction.class,
+    BucketRetentionAction.class, NamespaceAction.class,
+    NamespaceQuotaAction.class, NamespaceRetentionAction.class,
+    BucketAclAction.class, NFSExportAction.class, ObjectUserMapAction.class})
+
+public class ReclaimPolicyTests {
+    private static final String BASE_URL = "base-url";
+    private static final String REPOSITORY = "repository";
+    private static final String USER = "user";
+    private static final String HTTP = "http://";
+    private static final String _9020 = ":9020";
+    private static final String CREATE = "create";
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private BrokerConfig broker;
+
+    @Mock
+    private CatalogConfig catalog;
+
+    @Mock
+    private BucketWipeFactory bucketWipeFactory;
+
+    @Autowired
+    @InjectMocks
+    private EcsService ecs;
+
+    @Before
+    public void setUp() {
+        when(broker.getPrefix()).thenReturn(PREFIX);
+        when(broker.getReplicationGroup()).thenReturn(RG_NAME);
+        when(broker.getNamespace()).thenReturn(NAMESPACE);
+        when(broker.getRepositoryUser()).thenReturn(USER);
+        when(broker.getRepositoryBucket()).thenReturn(REPOSITORY);
+    }
+
+    /**
+     * When initializing the ecs-service, and object-endpoint, repo-user &
+     * repo-bucket are set, the service will use these static settings. It the
+     * repo facilities exist, the ecs-service will continue.
+     *
+     * @throws EcsManagementClientException po
+     */
+    @Test
+    public void initializeStaticConfigTest() throws EcsManagementClientException {
+        setupInitTest();
+        when(broker.getObjectEndpoint()).thenReturn(OBJ_ENDPOINT);
+
+        ecs.initialize();
+
+        assertEquals(OBJ_ENDPOINT, ecs.getObjectEndpoint());
+        assertEquals(PREFIX + "test", ecs.prefix(TEST));
+        verify(broker, times(1)).setRepositoryEndpoint(OBJ_ENDPOINT);
+        verify(broker, times(1)).setRepositorySecret(TEST);
+    }
+
+    /**
+     * When initializing the ecs-service, if the object-endpoint is not set
+     * statically, but base-url is, the service will look up the endpoint from
+     * the base-url.
+     *
+     * @throws EcsManagementClientException when ECS resources do not exist
+     */
+    @Test
+    public void initializeBaseUrlLookup() throws EcsManagementClientException {
+        setupInitTest();
+        setupBaseUrlTest(BASE_URL_NAME, false);
+
+        ecs.initialize();
+        String objEndpoint = HTTP + BASE_URL + _9020;
+        assertEquals(objEndpoint, ecs.getObjectEndpoint());
+        verify(broker, times(1)).setRepositoryEndpoint(objEndpoint);
+    }
+
+    /**
+     * When initializing the ecs-service, if neither the object-endpoint is not
+     * set statically nor the base-url, the service will lookup an endpoint
+     * named default in the base-url list. If one is found, it will set this as
+     * the repo endpoint.
+     *
+     * @throws EcsManagementClientException when ECS resources do not exist
+     */
+    @Test
+    public void initializeBaseUrlDefaultLookup() throws EcsManagementClientException {
+        PowerMockito.mockStatic(ReplicationGroupAction.class);
+
+        setupInitTest();
+        setupBaseUrlTest(DEFAULT_BASE_URL_NAME, false);
+
+        ecs.initialize();
+        String objEndpoint = HTTP + BASE_URL + _9020;
+        assertEquals(objEndpoint, ecs.getObjectEndpoint());
+        verify(broker, times(1)).setRepositoryEndpoint(objEndpoint);
+    }
+
+    /**
+     * When initializing the ecs-service, if neither the object-endpoint is not
+     * set statically nor the base-url, the service will lookup an endpoint
+     * named default in the base-url list. If none is found, it will throw an
+     * exception.
+     *
+     * @throws EcsManagementClientException when ECS resources do not exist
+     */
+    @Test(expected = ServiceBrokerException.class)
+    public void initializeBaseUrlDefaultLookupFails()
+        throws EcsManagementClientException {
+        PowerMockito.mockStatic(BaseUrlAction.class);
+        when(BaseUrlAction.list(same(connection)))
+            .thenReturn(Collections.emptyList());
+
+        ecs.initialize();
+    }
+
+    @Test
+    public void testReclaimPolicyExtraction() {
+        assertEquals(ReclaimPolicy.Fail, ReclaimPolicy.getReclaimPolicy(null));
+        assertEquals(ReclaimPolicy.Detach, ReclaimPolicy.getReclaimPolicy(Collections.singletonMap(RECLAIM_POLICY, ReclaimPolicy.Detach)));
+        assertEquals(ReclaimPolicy.Delete, ReclaimPolicy.getReclaimPolicy(Collections.singletonMap(RECLAIM_POLICY, ReclaimPolicy.Delete)));
+        assertEquals(ReclaimPolicy.Fail, ReclaimPolicy.getReclaimPolicy(Collections.singletonMap(RECLAIM_POLICY, ReclaimPolicy.Fail)));
+    }
+
+    @Test
+    public void testAllowedReclaimPolicyExtraction() {
+        Map<String, Object> params = new HashMap<>();
+
+        List<ReclaimPolicy> result = ReclaimPolicy.getAllowedReclaimPolicies(null);
+        assertThat(result, CoreMatchers.hasItems(ReclaimPolicy.Fail));
+
+        params.put(ALLOWED_RECLAIM_POLICIES, "Delete, Fail");
+        result = ReclaimPolicy.getAllowedReclaimPolicies(params);
+        assertThat(result, CoreMatchers.hasItems(ReclaimPolicy.Delete, ReclaimPolicy.Fail));
+
+        params.put(ALLOWED_RECLAIM_POLICIES, "Delete,Fail");
+        result = ReclaimPolicy.getAllowedReclaimPolicies(params);
+        assertThat(result, CoreMatchers.hasItems(ReclaimPolicy.Delete, ReclaimPolicy.Fail));
+
+        params.put(ALLOWED_RECLAIM_POLICIES, "Delete, Fail, Detach");
+        result = ReclaimPolicy.getAllowedReclaimPolicies(params);
+        assertThat(result, CoreMatchers.hasItems(ReclaimPolicy.Delete, ReclaimPolicy.Fail, ReclaimPolicy.Detach));
+
+
+        params.put(ALLOWED_RECLAIM_POLICIES, "Detach");
+        result = ReclaimPolicy.getAllowedReclaimPolicies(params);
+        assertThat(result, CoreMatchers.hasItems(ReclaimPolicy.Detach));
+    }
+
+    @Test
+    public void testReclaimPolicyValidation() {
+        Map<String, Object> params = new HashMap<>();
+
+        // With No Defined Allowed
+        assertTrue(ReclaimPolicy.isPolicyAllowed(params));
+
+        params.put(RECLAIM_POLICY, "Fail");
+        assertTrue(ReclaimPolicy.isPolicyAllowed(params));
+
+        params.put(RECLAIM_POLICY, "Delete");
+        assertFalse(ReclaimPolicy.isPolicyAllowed(params));
+
+        params.put(RECLAIM_POLICY, "Detach");
+        assertFalse(ReclaimPolicy.isPolicyAllowed(params));
+
+        // With Different Allowed defined
+        params.put(ALLOWED_RECLAIM_POLICIES, "Detach, Fail");
+        params.put(RECLAIM_POLICY, "Detach");
+        assertTrue(ReclaimPolicy.isPolicyAllowed(params));
+
+        params.put(ALLOWED_RECLAIM_POLICIES, "Fail,Detach");
+        params.put(RECLAIM_POLICY, "Detach");
+        assertTrue(ReclaimPolicy.isPolicyAllowed(params));
+
+        params.put(ALLOWED_RECLAIM_POLICIES, "Detach, Fail");
+        params.put(RECLAIM_POLICY, "Delete");
+        assertFalse(ReclaimPolicy.isPolicyAllowed(params));
+
+        params.put(ALLOWED_RECLAIM_POLICIES, "Detach, Fail");
+        params.put(RECLAIM_POLICY, "Delete");
+        assertFalse(ReclaimPolicy.isPolicyAllowed(params));
+    }
+
+    @Test
+    public void createBucketWithDefaultReclaimPolicies() throws Exception {
+        setupCreateBucketTest();
+
+        ServiceDefinitionProxy service = bucketServiceFixture();
+        PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
+
+        Map<String, Object> params = new HashMap<>();
+        ecs.createBucket(BUCKET_NAME, service, plan, params);
+    }
+
+    @Test
+    public void createBucketWithAllowedReclaimPolicies() throws Exception {
+        setupCreateBucketTest();
+
+        ServiceDefinitionProxy service = bucketServiceFixture();
+        PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
+
+        Map<String, Object> params = new HashMap<>();
+
+        service.getServiceSettings().put(ALLOWED_RECLAIM_POLICIES, "Delete, Detach");
+        params.put(RECLAIM_POLICY, ReclaimPolicy.Delete);
+        ecs.createBucket(BUCKET_NAME, service, plan, params);
+
+        service.getServiceSettings().put(ALLOWED_RECLAIM_POLICIES, "Detach,Fail");
+        params.put(RECLAIM_POLICY, ReclaimPolicy.Fail);
+        ecs.createBucket(BUCKET_NAME, service, plan, params);
+
+        service.getServiceSettings().put(ALLOWED_RECLAIM_POLICIES, "Delete, Detach");
+        params.put(RECLAIM_POLICY, ReclaimPolicy.Detach);
+        ecs.createBucket(BUCKET_NAME, service, plan, params);
+    }
+
+    @Test
+    public void createBucketWithWrongReclaimPolicies() throws Exception {
+        setupCreateBucketTest();
+
+        ServiceDefinitionProxy service = bucketServiceFixture();
+        PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
+
+        Map<String, Object> params = new HashMap<>();
+
+        try {
+            service.getServiceSettings().put(ALLOWED_RECLAIM_POLICIES, "Detach");
+            params.put(RECLAIM_POLICY, ReclaimPolicy.Delete);
+            ecs.createBucket(BUCKET_NAME, service, plan, params);
+            fail("Expected Exception");
+        }catch(Exception ignore) {
+        }
+
+        try {
+            service.getServiceSettings().put(ALLOWED_RECLAIM_POLICIES, "Delete");
+            params.put(RECLAIM_POLICY, ReclaimPolicy.Fail);
+            ecs.createBucket(BUCKET_NAME, service, plan, params);
+            fail("Expected Exception");
+        }catch(Exception ignore) {
+        }
+
+        try {
+            service.getServiceSettings().put(ALLOWED_RECLAIM_POLICIES, "Fail");
+            params.put(RECLAIM_POLICY, ReclaimPolicy.Detach);
+            ecs.createBucket(BUCKET_NAME, service, plan, params);
+            fail("Expected Exception");
+        }catch(Exception ignore) {
+        }
+    }
+
+
+    private void setupInitTest() throws EcsManagementClientException {
+        DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
+        rg.setName(RG_NAME);
+        rg.setId(RG_ID);
+        UserSecretKey secretKey = new UserSecretKey();
+
+        secretKey.setSecretKey(TEST);
+        PowerMockito.mockStatic(BucketAction.class);
+        when(BucketAction.exists(connection, REPO_BUCKET, NAMESPACE))
+            .thenReturn(true);
+
+        PowerMockito.mockStatic(ReplicationGroupAction.class);
+        when(ReplicationGroupAction.list(connection))
+            .thenReturn(Collections.singletonList(rg));
+
+        PowerMockito.mockStatic(ObjectUserAction.class);
+        when(ObjectUserAction.exists(connection, REPO_USER, NAMESPACE))
+            .thenReturn(true);
+
+        PowerMockito.mockStatic(ObjectUserSecretAction.class);
+        when(ObjectUserSecretAction.list(connection, REPO_USER))
+            .thenReturn(Collections.singletonList(secretKey));
+    }
+
+    private void setupBaseUrlTest(String name, boolean namespaceInHost) throws EcsManagementClientException {
+        PowerMockito.mockStatic(BaseUrlAction.class);
+        BaseUrl baseUrl = new BaseUrl();
+        baseUrl.setId(BASE_URL_ID);
+        baseUrl.setName(name);
+        when(BaseUrlAction.list(same(connection)))
+            .thenReturn(Collections.singletonList(baseUrl));
+
+        BaseUrlInfo baseUrlInfo = new BaseUrlInfo();
+        baseUrlInfo.setId(BASE_URL_ID);
+        baseUrlInfo.setName(name);
+        baseUrlInfo.setNamespaceInHost(namespaceInHost);
+        baseUrlInfo.setBaseurl(BASE_URL);
+        when(BaseUrlAction.get(connection, BASE_URL_ID))
+            .thenReturn(baseUrlInfo);
+    }
+
+    private void setupCreateBucketTest() throws Exception {
+        PowerMockito.mockStatic(BucketAction.class);
+        PowerMockito.doNothing().when(BucketAction.class, CREATE,
+            same(connection), any(ObjectBucketCreate.class));
+    }
+}


### PR DESCRIPTION
This PR adds support for the Bucket `ReclaimPolicy` which indicates to the Broker how it should treat a bucket during a delete operation.

The following `ReclaimPolicy` values are supported:
- `Fail` -  (Default) Attempt to delete the bucket but fail if it is not empty
- `Detach` - Do not delete the bucket, instead just delete it from the repository leaving the bucket intact
- `Delete` - Delete all data in the bucket and then delete the bucket

Users indicate the required `ReclaimPolicy` using the `reclaim-policy` parameter during Instance creation.

_Allowed Policies_
Data protection is very important to a lot of users and therefore this PR allows the Services to be configured with a restrictive set of `ReclaimPolicy`.  This is achieve by supplying the `allowed-reclaim-policies` parameter within the service definition configuration.  

For example the following would allow users to ONLY use `Fail` or `Detach` thereby ensuring that data is never deleted by the broker:
```
        service-settings:
          access-during-outage: true
          head-type: s3
          service-type: bucket
          allowed-reclaim-policies: Fail, Detach
```

If a user attempts to create a service with a `ReclaimPolicy` not in the allowed list, the broker will reject the instance creation:
```
2020-04-17 12:51:44.086 ERROR 1 --- [nio-8080-exec-9] c.e.e.s.s.EcsServiceInstanceService      : Unexpected error creating service be92d3ae-563c-435c-a3a2-81417f164632

org.springframework.cloud.servicebroker.exception.ServiceBrokerException: org.springframework.cloud.servicebroker.exception.ServiceBrokerException: Reclaim Policy Delete is not one of the allowed polices [Fail, Detach]
...
...
```
This same check is performed during a bucket plan update.

_Default Behaviour_
If `allowed-reclaim-policies` is NOT specified in the service, it defaults to only allowing `Fail` which mirrors exactly how the broker currently works.  The administrator must supply an `allowed-reclaim-policies` parameter in order to enable `Detach` or `Delete` thus providing a further level of data safety.

If `reclaim-policy` is not specified during instance creation, it defaults to `Fail`, again mirroring exactly how the current broker works.

_Locking ReclaimPolicy_
It may be desirable to lock all instances created by the broker to a particular `ReclaimPolicy`, i.e. `Detatch`.  This can be achieved by setting both an `allowed-reclaim-policies` and `reclaim-policy` on a service definition to the same value.  Due to the way parameter inheritance works, the service settings will override any provided by the user.

**Implementation Notes**
This brings in the ECS BucketWipe utility (https://github.com/EMCECS/bucket-wipe) that was previously converted to a library and published on Maven Central.  The library is ONLY used to delete bucket contents if the `ReclaimPolicy` is `Delete`.

Normally the responses for Delete are synchronous, however deletion of bucket contents may take some time and therefore for a `ReclaimPolicy` `Delete` request the response is returned asynchronously.  This involves setting the `lastOperation` to `IN_PROGRESS` on the `ServiceInstance` and then updating it to `SUCCESS` when the `CompletableFuture` from the Bucket Wipe call has completed.  

This asynchronous response has been tested with Kubernetes ServiceCatalog and works as expected with the instance being marked as "InFlight" during deprovisioning.

**Outstanding Work**
This PR still needs Unit tests that are currently being constructed.