### PR TITLE
Issue-91 Handle non-existent items when deleting

### DIFF
--- a/src/main/java/com/emc/ecs/management/sdk/BucketAclAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BucketAclAction.java
@@ -29,4 +29,11 @@ public final class BucketAclAction {
         return response.readEntity(BucketAcl.class);
     }
 
+    public static boolean exists(Connection connection, String id,
+                                 String namespace) throws EcsManagementClientException {
+        UriBuilder uri = connection.getUriBuilder()
+            .segment(OBJECT, BUCKET, id, ACL)
+            .queryParam(NAMESPACE, namespace);
+        return connection.existenceQuery(uri, null);
+    }
 }

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -83,7 +83,11 @@ public class EcsService {
 
     CompletableFuture deleteBucket(String id) {
         try {
-            BucketAction.delete(connection, prefix(id), broker.getNamespace());
+            if (bucketExists(prefix(id))) {
+                BucketAction.delete(connection, prefix(id), broker.getNamespace());
+            } else {
+                logger.info("Bucket {} no longer exists, assume already deleted", prefix(id));
+            }
 
             return null;
         } catch (Exception e) {
@@ -93,6 +97,11 @@ public class EcsService {
 
     CompletableFuture wipeAndDeleteBucket(String id) {
         try {
+            if (!bucketExists(prefix(id))) {
+                logger.info("Bucket {} no longer exists, assume already deleted", prefix(id));
+                return null;
+            }
+
             addUserToBucket(id, broker.getRepositoryUser());
 
             logger.info("Started Wiped of bucket {}", prefix(id));
@@ -230,7 +239,11 @@ public class EcsService {
     }
 
     void deleteUser(String id) throws EcsManagementClientException {
-        ObjectUserAction.delete(connection, prefix(id));
+        if (userExists(id)) {
+            ObjectUserAction.delete(connection, prefix(id));
+        } else {
+            logger.info("User {} no longer exists, assume already deleted", id);
+        }
     }
 
     void addUserToBucket(String id, String username) {
@@ -269,6 +282,11 @@ public class EcsService {
 
     void removeUserFromBucket(String id, String username)
             throws EcsManagementClientException {
+        if (!bucketExists(prefix(id))) {
+            logger.info("Bucket {} no longer exists when removing user {}", prefix(id), prefix(username));
+            return;
+        }
+
         BucketAcl acl = BucketAclAction.get(connection, prefix(id),
                 broker.getNamespace());
         List<BucketUserAcl> newUserAcl = acl.getAcl().getUserAccessList()
@@ -468,7 +486,11 @@ public class EcsService {
     }
 
     void deleteNamespace(String id) throws EcsManagementClientException {
-        NamespaceAction.delete(connection, prefix(id));
+        if (namespaceExists(prefix((id)))) {
+            NamespaceAction.delete(connection, prefix(id));
+        } else {
+            logger.info("Namespace {} no longer exists, assume already deleted", prefix(id));
+        }
     }
 
     /**

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -282,11 +282,6 @@ public class EcsService {
 
     void removeUserFromBucket(String id, String username)
             throws EcsManagementClientException {
-        if (!bucketExists(prefix(id))) {
-            logger.info("Bucket {} no longer exists when removing user {}", prefix(id), prefix(username));
-            return;
-        }
-
         BucketAcl acl = BucketAclAction.get(connection, prefix(id),
                 broker.getNamespace());
         List<BucketUserAcl> newUserAcl = acl.getAcl().getUserAccessList()
@@ -510,8 +505,8 @@ public class EcsService {
         // Wipe Succeeded, Attempt Bucket Delete
         try {
             logger.info("BucketWipe SUCCEEDED, deleted {} objects, Deleting bucket {}", result.getDeletedObjects(), prefix(id));
-            BucketAction.delete(connection, prefix(id), broker.getNamespace());
-        } catch (EcsManagementClientException e) {
+            deleteBucket(id);
+        } catch (Exception e) {
             logger.error("Error deleting bucket "+prefix(id), e);
             throw new RuntimeException("Error Deleting Bucket "+prefix(id)+" "+e.getMessage());
         }

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -200,6 +200,11 @@ public class EcsService {
                 broker.getNamespace());
     }
 
+    private boolean aclExists(String id) throws EcsManagementClientException {
+        return BucketAclAction.exists(connection, prefix(id),
+            broker.getNamespace());
+    }
+
     UserSecretKey createUser(String id) {
         try {
             logger.info(String.format("Creating user %s", prefix(id)));
@@ -282,6 +287,11 @@ public class EcsService {
 
     void removeUserFromBucket(String id, String username)
             throws EcsManagementClientException {
+        if (!aclExists(id)) {
+            logger.info("ACL {} no longer exists when removing user {}", prefix(id), prefix(username));
+            return;
+        }
+
         BucketAcl acl = BucketAclAction.get(connection, prefix(id),
                 broker.getNamespace());
         List<BucketUserAcl> newUserAcl = acl.getAcl().getUserAccessList()


### PR DESCRIPTION
When `ECSService` is asked to delete artifacts it currently fails if that artifact (namespace, user, bucket) has already been deleted.  This PR tests to see if the requested artifact still exists before initiating the delete request to ECS.