### PR TITLE
Fix classpath issue + additional logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,14 +37,16 @@ dependencies {
     compile(group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: springBootVersion)
     compile(group: 'org.springframework.boot', name: 'spring-boot-devtools', version: springBootVersion)
     compile(group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion)
-    compile(group: 'org.springframework.cloud', name: 'spring-cloud-starter-open-service-broker',
-            version: springCloudServiceBrokerVersion)
+    compile(group: 'org.springframework.cloud', name: 'spring-cloud-starter-open-service-broker', version: springCloudServiceBrokerVersion)
+    compile(group: 'com.google.guava', name: 'guava', version: '28.2-jre')
+
     compile(group: 'com.emc.ecs', name: 'object-client', version: '3.1.3') {
         exclude module: "slf4j-log4j12"
+        exclude module: "jsr311-api"
     }
-    compile(group: 'com.google.guava', name: 'guava', version: '28.2-jre')
     compile(group: 'com.emc.ecs', name: 'bucket-wipe', version: '2.0.0') {
         exclude module: "slf4j-log4j12"
+        exclude module: "jsr311-api"
     }
 
     testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion)

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -210,13 +210,6 @@ public class Connection {
             return response;
         } catch (Exception e) {
             logger.warn("Failed to make a call to {}: {}", uri, e.getMessage());
-            logger.warn(e.getMessage(), e.getCause());
-            if (e.getCause() != null) {
-                logger.warn(e.getCause().getMessage(), e.getCause().getCause());
-            }
-            if (e.getCause() != null && e.getCause().getCause() != null) {
-                logger.warn(e.getCause().getCause().getMessage());
-            }
             throw e;
         }
     }

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -111,19 +111,13 @@ public class Connection {
     public void login() throws EcsManagementClientException {
         UriBuilder uriBuilder = UriBuilder.fromPath(endpoint).segment("login");
 
-        logger.info("Logging into {}", endpoint);
-
-        logger.info("Current classpath: {}", System.getProperty("java.class.path"));
+        logger.info("Logging into {} as {}", endpoint, username);
 
         HttpAuthenticationFeature authFeature = HttpAuthenticationFeature
                 .basicBuilder().credentials(username, password).build();
         Client jerseyClient = buildJerseyClient().register(authFeature);
 
-        logger.info("Jersey client registered: {}", jerseyClient);
-
         Builder request = jerseyClient.target(uriBuilder).request();
-
-        logger.info("Request prepared: {}", request);
 
         Response response = request.get();
         try {
@@ -174,14 +168,13 @@ public class Connection {
             if (!isLoggedIn())
                 login();
 
+            logger.info("Making {} request to {}", method, uri);
+
             Client jerseyClient = buildJerseyClient();
             Builder request = jerseyClient.target(uri)
                     .register(LoggingFeature.class).request()
                     .header("X-SDS-AUTH-TOKEN", authToken)
                     .header("Accept", "application/xml");
-
-            logger.info("Request target " + uri);
-            logger.info("Making request " + request.toString());
 
             Response response = null;
             if (GET.equals(method)) {
@@ -216,7 +209,7 @@ public class Connection {
             }
             return response;
         } catch (Exception e) {
-            logger.warn("Failed to make a call: {}", e.getMessage());
+            logger.warn("Failed to make a call to {}: {}", uri, e.getMessage());
             logger.warn(e.getMessage(), e.getCause());
             if (e.getCause() != null) {
                 logger.warn(e.getCause().getMessage(), e.getCause().getCause());

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -68,6 +68,8 @@ public class EcsService {
 
     @PostConstruct
     void initialize() {
+        logger.info("Initializing ECS service with management endpoint {}, base url {}", broker.getManagementEndpoint(), broker.getBaseUrl());
+
         try {
             lookupObjectEndpoints();
             lookupReplicationGroupID();
@@ -409,8 +411,7 @@ public class EcsService {
         return baseUrlList.get(0).getId();
     }
 
-    private Boolean namespaceExists(String id)
-            throws EcsManagementClientException {
+    private Boolean namespaceExists(String id) throws EcsManagementClientException {
         return NamespaceAction.exists(connection, prefix(id));
     }
 
@@ -434,8 +435,7 @@ public class EcsService {
         }
     }
 
-    Map<String, Object> createNamespace(String id, ServiceDefinitionProxy service,
-                                        PlanProxy plan, Map<String, Object> parameters)
+    Map<String, Object> createNamespace(String id, ServiceDefinitionProxy service, PlanProxy plan, Map<String, Object> parameters)
             throws EcsManagementClientException {
         if (namespaceExists(id))
             throw new ServiceInstanceExistsException(id, service.getId());

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
@@ -60,18 +60,19 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
         String serviceDefinitionId = request.getServiceDefinitionId();
         String planId = request.getPlanId();
 
-        logger.info(format("Creating service instance %s", serviceInstanceId));
+        logger.info(format("Creating service instance %s for service definition %s", serviceInstanceId, serviceDefinitionId));
+        logger.info(format("Create request params: %s", request));
 
         try {
-            ServiceDefinitionProxy service = ecs
-                    .lookupServiceDefinition(serviceDefinitionId);
+            ServiceDefinitionProxy service = ecs.lookupServiceDefinition(serviceDefinitionId);
+
+            logger.info(format("Service definition: %s", service));
+
             PlanProxy plan = service.findPlan(planId);
-            InstanceWorkflow workflow = getWorkflow(request)
-                    .withCreateRequest(request);
+            InstanceWorkflow workflow = getWorkflow(request).withCreateRequest(request);
 
             LOG.info("creating service instance");
-            ServiceInstance instance =
-                    workflow.create(serviceInstanceId, service, plan, request.getParameters());
+            ServiceInstance instance = workflow.create(serviceInstanceId, service, plan, request.getParameters());
 
             LOG.info("saving instance...");
             repository.save(instance);


### PR DESCRIPTION
Fixing an issue occuring in CF:

An attempt was made to call a method that does not exist. The attempt was made from the following location:  
    org.glassfish.jersey.message.internal.Statuses$StatusImpl.<init>(Statuses.java:40)  
The following method did not exist:  
    javax.ws.rs.core.Response$Status$Family.familyOf(I)Ljavax/ws/rs/core/Response$Status$Family;  
The method's class, javax.ws.rs.core.Response$Status$Family, is available from the following locations:  
    jar:file:/home/vcap/app/BOOT-INF/lib/jsr311-api-1.1.1.jar!/javax/ws/rs/core/Response$Status$Family.class  
    jar:file:/home/vcap/app/BOOT-INF/lib/jakarta.ws.rs-api-2.1.6.jar!/javax/ws/rs/core/Response$Status$Family.class  
It was loaded from the following location:  
    file:/home/vcap/app/BOOT-INF/lib/jsr311-api-1.1.1.jar 