### PR TITLE
Issue-155 Fix Delete Reclaim Policy

### DIFF
--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -85,7 +85,7 @@ public class EcsService {
 
     CompletableFuture deleteBucket(String id) {
         try {
-            if (bucketExists(prefix(id))) {
+            if (bucketExists(id)) {
                 BucketAction.delete(connection, prefix(id), broker.getNamespace());
             } else {
                 logger.info("Bucket {} no longer exists, assume already deleted", prefix(id));
@@ -99,7 +99,7 @@ public class EcsService {
 
     CompletableFuture wipeAndDeleteBucket(String id) {
         try {
-            if (!bucketExists(prefix(id))) {
+            if (!bucketExists(id)) {
                 logger.info("Bucket {} no longer exists, assume already deleted", prefix(id));
                 return null;
             }


### PR DESCRIPTION
Fixes the Delete `reclaim-policy` which was broken due to the the prefix being applied twice.  Two new tests have been added to validate that the `wipeAndDeleteBucket` and the `deleteBucket` methods are working correctly.

**Test Results**
*Before Fix:*
```
EcsServiceTest.wipeBucketTest			failed	 41ms
org.junit.ComparisonFailure: 
Expected :ecs-cf-broker-testbucket1
Actual   :ecs-cf-broker-ecs-cf-broker-testbucket1

EcsServiceTest.deleteBucketTest			failed	 4ms
org.junit.ComparisonFailure: 
Expected :ecs-cf-broker-testbucket1
Actual   :ecs-cf-broker-ecs-cf-broker-testbucket1

```
*After Fix*
```
EcsServiceTest.wipeBucketTest          passed     38ms
EcsServiceTest.deleteBucketTest        passed      2ms
```
Broker Logs when deleting bucket `octopus-cb280edc-dd2a-4836-805e-854ce18f1bac`
```
2020-08-06 17:03:42.243  INFO 1 --- [nio-8080-exec-6] c.e.e.s.s.EcsServiceInstanceService      : Deleting service instance cb280edc-dd2a-4836-805e-854ce18f1bac
2020-08-06 17:03:42.248  INFO 1 --- [nio-8080-exec-6] c.e.e.s.service.BucketInstanceWorkflow   : Reclaim Policy is Delete for bucket octopus-cb280edc-dd2a-4836-805e-854ce18f1bac, Wiping and Deleting bucket
2020-08-06 17:03:42.248  INFO 1 --- [nio-8080-exec-6] com.emc.ecs.management.sdk.Connection    : Making get request to https://10.243.86.70:4443/object/bucket/octopus-cb280edc-dd2a-4836-805e-854ce18f1bac/info?namespace=nightshift
2020-08-06 17:03:42.290  INFO 1 --- [nio-8080-exec-6] c.e.e.servicebroker.service.EcsService   : Adding user user to bucket cb280edc-dd2a-4836-805e-854ce18f1bac
2020-08-06 17:03:42.290  INFO 1 --- [nio-8080-exec-6] c.e.e.servicebroker.service.EcsService   : Adding user octopus-user to bucket octopus-cb280edc-dd2a-4836-805e-854ce18f1bac
2020-08-06 17:03:42.291  INFO 1 --- [nio-8080-exec-6] com.emc.ecs.management.sdk.Connection    : Making get request to https://10.243.86.70:4443/object/bucket/octopus-cb280edc-dd2a-4836-805e-854ce18f1bac/acl?namespace=nightshift
2020-08-06 17:03:42.348  INFO 1 --- [nio-8080-exec-6] com.emc.ecs.management.sdk.Connection    : Making put request to https://10.243.86.70:4443/object/bucket/octopus-cb280edc-dd2a-4836-805e-854ce18f1bac/acl
2020-08-06 17:03:42.483  INFO 1 --- [nio-8080-exec-6] com.emc.ecs.management.sdk.Connection    : Making get request to https://10.243.86.70:4443/object/bucket/octopus-cb280edc-dd2a-4836-805e-854ce18f1bac/info?namespace=nightshift
2020-08-06 17:03:42.691  INFO 1 --- [nio-8080-exec-6] com.emc.ecs.management.sdk.Connection    : Making put request to https://10.243.86.70:4443/object/bucket/octopus-cb280edc-dd2a-4836-805e-854ce18f1bac/policy?namespace=nightshift
2020-08-06 17:03:42.779  INFO 1 --- [nio-8080-exec-6] c.e.e.servicebroker.service.EcsService   : Started Wiped of bucket octopus-cb280edc-dd2a-4836-805e-854ce18f1bac
2020-08-06 17:03:43.018  INFO 1 --- [nio-8080-exec-6] c.e.e.servicebroker.service.EcsService   : BucketWipe SUCCEEDED, deleted 0 objects, Deleting bucket octopus-cb280edc-dd2a-4836-805e-854ce18f1bac
2020-08-06 17:03:43.019  INFO 1 --- [nio-8080-exec-6] com.emc.ecs.management.sdk.Connection    : Making get request to https://10.243.86.70:4443/object/bucket/octopus-cb280edc-dd2a-4836-805e-854ce18f1bac/info?namespace=nightshift
2020-08-06 17:03:43.055  INFO 1 --- [nio-8080-exec-6] com.emc.ecs.management.sdk.Connection    : Making post request to https://10.243.86.70:4443/object/bucket/octopus-cb280edc-dd2a-4836-805e-854ce18f1bac/deactivate?namespace=nightshift
2020-08-06 17:03:43.220  INFO 1 --- [nio-8080-exec-6] c.e.e.s.r.ServiceInstanceRepository      : Host: 10.243.86.70, Namespace: null, Protocol: HTTP, Identity: octopus-user, Port: 9020
2020-08-06 17:03:43.224  INFO 1 --- [nio-8080-exec-6] c.e.e.s.r.ServiceInstanceRepository      : Saving Repository - bucket: octopus-repository
2020-08-06 17:03:43.286  INFO 1 --- [nio-8080-exec-6] c.e.e.s.r.ServiceInstanceRepository      : Host: 10.243.86.70, Namespace: null, Protocol: HTTP, Identity: octopus-user, Port: 9020
2020-08-06 17:03:43.286  INFO 1 --- [nio-8080-exec-6] c.e.e.s.r.ServiceInstanceRepository      : Saving Repository - bucket: octopus-repository
2020-08-06 17:03:44.317  INFO 1 --- [nio-8080-exec-7] c.e.e.s.s.EcsServiceInstanceService      : Operation for cb280edc-dd2a-4836-805e-854ce18f1bac completed successfully, deleting from repository
```