### PR TITLE
Add override header to to support ECS Flex

### DIFF
--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -184,6 +184,7 @@ public class Connection {
             Client jerseyClient = buildJerseyClient();
             Builder request = jerseyClient.target(uri)
                     .register(LoggingFeature.class).request()
+                    .header("X-EMC-Override", "true")
                     .header("X-SDS-AUTH-TOKEN", authToken)
                     .header("Accept", "application/xml");
 


### PR DESCRIPTION
Addresses #163 

ECS Flex disables direct access to the management API from external clients by default.  This limitation will be lifted before GA once Flex incorporates the new IAM APIs.  In the meantime, adding the override header, allows client access to these restricted APIs.