### PR TITLE
Bug 152 no error message in response

### DIFF
--- a/src/main/java/com/emc/ecs/management/sdk/BaseUrlAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BaseUrlAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.BaseUrl;
 import com.emc.ecs.management.sdk.model.BaseUrlInfo;
 import com.emc.ecs.management.sdk.model.BaseUrlList;

--- a/src/main/java/com/emc/ecs/management/sdk/BucketAclAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BucketAclAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.BucketAcl;
 
 import javax.ws.rs.core.Response;

--- a/src/main/java/com/emc/ecs/management/sdk/BucketAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BucketAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.ObjectBucketCreate;
 import com.emc.ecs.management.sdk.model.ObjectBucketInfo;
 

--- a/src/main/java/com/emc/ecs/management/sdk/BucketPolicyAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BucketPolicyAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.service.EcsServiceInstanceBindingService;
 import com.emc.ecs.management.sdk.model.BucketPolicy;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/emc/ecs/management/sdk/BucketQuotaAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BucketQuotaAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.BucketQuotaDetails;
 import com.emc.ecs.management.sdk.model.BucketQuotaParam;
 

--- a/src/main/java/com/emc/ecs/management/sdk/BucketRetentionAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BucketRetentionAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.DefaultBucketRetention;
 import com.emc.ecs.management.sdk.model.DefaultBucketRetentionUpdate;
 

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -1,9 +1,9 @@
 package com.emc.ecs.management.sdk;
 
 import com.emc.ecs.management.sdk.model.EcsManagementClientError;
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementClientUnauthorizedException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientUnauthorizedException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/emc/ecs/management/sdk/NFSExportAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/NFSExportAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.NFSExport;
 import com.emc.ecs.management.sdk.model.NFSExportList;
 import com.emc.ecs.management.sdk.model.NFSExportsOption;

--- a/src/main/java/com/emc/ecs/management/sdk/NamespaceAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/NamespaceAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.NamespaceCreate;
 import com.emc.ecs.management.sdk.model.NamespaceInfo;
 import com.emc.ecs.management.sdk.model.NamespaceUpdate;

--- a/src/main/java/com/emc/ecs/management/sdk/NamespaceQuotaAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/NamespaceQuotaAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.NamespaceQuotaDetails;
 import com.emc.ecs.management.sdk.model.NamespaceQuotaParam;
 

--- a/src/main/java/com/emc/ecs/management/sdk/NamespaceRetentionAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/NamespaceRetentionAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.RetentionClassCreate;
 import com.emc.ecs.management.sdk.model.RetentionClassDetails;
 import com.emc.ecs.management.sdk.model.RetentionClassUpdate;

--- a/src/main/java/com/emc/ecs/management/sdk/ObjectUserAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/ObjectUserAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.UserCreateParam;
 import com.emc.ecs.management.sdk.model.UserDeleteParam;
 

--- a/src/main/java/com/emc/ecs/management/sdk/ObjectUserMapAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/ObjectUserMapAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.ObjectNFSAddUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/emc/ecs/management/sdk/ObjectUserSecretAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/ObjectUserSecretAction.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.UserSecretKey;
 import com.emc.ecs.management.sdk.model.UserSecretKeyCreate;
 import com.emc.ecs.management.sdk.model.UserSecretKeyList;

--- a/src/main/java/com/emc/ecs/management/sdk/ReplicationGroupAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/ReplicationGroupAction.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.management.sdk.model.DataServiceReplicationGroup;
 import com.emc.ecs.management.sdk.model.DataServiceReplicationGroupList;
 

--- a/src/main/java/com/emc/ecs/servicebroker/EcsManagementClientException.java
+++ b/src/main/java/com/emc/ecs/servicebroker/EcsManagementClientException.java
@@ -1,5 +1,9 @@
 package com.emc.ecs.servicebroker;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.INTERNAL_SERVER_ERROR)
 public class EcsManagementClientException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/emc/ecs/servicebroker/EcsManagementResourceNotFoundException.java
+++ b/src/main/java/com/emc/ecs/servicebroker/EcsManagementResourceNotFoundException.java
@@ -1,7 +1,11 @@
 package com.emc.ecs.servicebroker;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 import java.util.NoSuchElementException;
 
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class EcsManagementResourceNotFoundException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/emc/ecs/servicebroker/config/Application.java
+++ b/src/main/java/com/emc/ecs/servicebroker/config/Application.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.servicebroker.config;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceBindingRepository;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
 import com.emc.ecs.servicebroker.repository.BucketWipeFactory;

--- a/src/main/java/com/emc/ecs/servicebroker/exception/EcsManagementClientException.java
+++ b/src/main/java/com/emc/ecs/servicebroker/exception/EcsManagementClientException.java
@@ -1,10 +1,11 @@
-package com.emc.ecs.servicebroker;
+package com.emc.ecs.servicebroker.exception;
 
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(code = HttpStatus.INTERNAL_SERVER_ERROR)
-public class EcsManagementClientException extends Exception {
+public class EcsManagementClientException extends ServiceBrokerException {
     private static final long serialVersionUID = 1L;
 
     public EcsManagementClientException(String message) {

--- a/src/main/java/com/emc/ecs/servicebroker/exception/EcsManagementClientUnauthorizedException.java
+++ b/src/main/java/com/emc/ecs/servicebroker/exception/EcsManagementClientUnauthorizedException.java
@@ -1,4 +1,4 @@
-package com.emc.ecs.servicebroker;
+package com.emc.ecs.servicebroker.exception;
 
 public class EcsManagementClientUnauthorizedException extends EcsManagementClientException {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/emc/ecs/servicebroker/exception/EcsManagementResourceNotFoundException.java
+++ b/src/main/java/com/emc/ecs/servicebroker/exception/EcsManagementResourceNotFoundException.java
@@ -1,7 +1,4 @@
-package com.emc.ecs.servicebroker;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
+package com.emc.ecs.servicebroker.exception;
 
 import java.util.NoSuchElementException;
 

--- a/src/main/java/com/emc/ecs/servicebroker/repository/ServiceInstanceBindingRepository.java
+++ b/src/main/java/com/emc/ecs/servicebroker/repository/ServiceInstanceBindingRepository.java
@@ -1,8 +1,8 @@
 package com.emc.ecs.servicebroker.repository;
 
 import com.emc.ecs.management.sdk.ObjectUserMapAction;
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.servicebroker.config.BrokerConfig;
 import com.emc.object.s3.S3Config;
 import com.emc.object.s3.bean.GetObjectResult;

--- a/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflow.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.servicebroker.service;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceBinding;
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceAppBindingResponse;
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingRequest;

--- a/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflowImpl.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BindingWorkflowImpl.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.servicebroker.service;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.model.PlanProxy;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;
@@ -12,7 +12,6 @@ import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstan
 import org.springframework.cloud.servicebroker.model.binding.DeleteServiceInstanceBindingRequest;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/BucketBindingWorkflow.java
@@ -1,14 +1,12 @@
 package com.emc.ecs.servicebroker.service;
 
 import com.emc.ecs.management.sdk.model.UserSecretKey;
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.repository.ServiceInstance;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceBinding;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
-import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceAppBindingResponse;
 import org.springframework.cloud.servicebroker.model.binding.SharedVolumeDevice;
 import org.springframework.cloud.servicebroker.model.binding.VolumeMount;

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -2,7 +2,7 @@ package com.emc.ecs.servicebroker.service;
 
 import com.emc.ecs.management.sdk.*;
 import com.emc.ecs.management.sdk.model.*;
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.config.BrokerConfig;
 import com.emc.ecs.servicebroker.config.CatalogConfig;
 import com.emc.ecs.servicebroker.model.PlanProxy;

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingService.java
@@ -22,9 +22,10 @@ import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.util.Map;
 
+import static java.lang.String.format;
+
 @Service
-public class EcsServiceInstanceBindingService
-        implements ServiceInstanceBindingService {
+public class EcsServiceInstanceBindingService implements ServiceInstanceBindingService {
     private static final String NAMESPACE = "namespace";
     private static final String BUCKET = "bucket";
 
@@ -65,8 +66,9 @@ public class EcsServiceInstanceBindingService
 
             return Mono.just(workflow.getResponse(credentials));
         } catch (IOException | JAXBException | EcsManagementClientException e) {
-            LOG.error("Error ", e);
-            throw new ServiceBrokerException(e);
+            String errorMessage = format("Error creating binding '%s' for service '%s': %s", request.getBindingId(), request.getServiceInstanceId(), e.getMessage());
+            LOG.error(errorMessage, e);
+            throw new ServiceBrokerException(errorMessage, e);
         }
     }
 
@@ -99,8 +101,9 @@ public class EcsServiceInstanceBindingService
                             .build()
             );
         } catch (Exception e) {
-            LOG.error("Error deleting binding: " + e);
-            throw new ServiceBrokerException(e);
+            String errorMessage = format("Error deleting binding '%s' for service '%s': %s", request.getBindingId(), request.getServiceInstanceId(), e.getMessage());
+            LOG.error(errorMessage, e);
+            throw new ServiceBrokerException(errorMessage, e);
         }
     }
 

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingService.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.servicebroker.service;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceBinding;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceBindingRepository;

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
@@ -75,8 +75,9 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
                     .async(false)
                     .build());
         } catch (Exception e) {
-            LOG.error(format("Unexpected error creating service %s", serviceInstanceId), e);
-            throw new ServiceBrokerException(e);
+            String errorMessage = format("Error creating service %s: %s", serviceInstanceId, e.getMessage());
+            LOG.error(errorMessage, e);
+            throw new ServiceBrokerException(errorMessage, e);
         }
     }
 
@@ -125,8 +126,9 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
                     .async(future != null)
                     .build());
         } catch (Exception e) {
-            LOG.error("Error Deleting", e);
-            throw new ServiceBrokerException(e);
+            String errorMessage = format("Error deleting service %s: %s", serviceInstanceId, e.getMessage());
+            LOG.error(errorMessage, e);
+            throw new ServiceBrokerException(errorMessage, e);
         }
     }
 
@@ -165,7 +167,9 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
             // Rethrow "does not exist" so that it's not caught by the generic case
             throw e;
         } catch (Exception e) {
-            throw new ServiceBrokerException(e);
+            String errorMessage = format("Error updating service %s: %s", serviceInstanceId, e.getMessage());
+            LOG.error(errorMessage, e);
+            throw new ServiceBrokerException(errorMessage, e);
         }
     }
 
@@ -195,7 +199,9 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
                     .operationState(lastOperation.getOperationState())
                     .build());
         } catch (IOException e) {
-            throw new ServiceBrokerException(e);
+            String errorMessage = format("Error getting last operation for service %s: %s", request.getServiceInstanceId(), e.getMessage());
+            LOG.error(errorMessage, e);
+            throw new ServiceBrokerException(errorMessage, e);
         }
     }
 
@@ -232,7 +238,7 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
             }
 
             if (exception == null) {
-                LOG.info("Setting last operation state 'Succeeded - Delete complete' on instance '{}'", instance.getServiceInstanceId());
+                LOG.info("Setting last operation state 'Succeeded - Delete complete' on instance '{}'", instance != null ? instance.getServiceInstanceId() : null);
                 instance.setLastOperation(new LastOperationSerializer(OperationState.SUCCEEDED, "Delete Complete", true));
             } else {
                 String errorMsg;
@@ -242,13 +248,13 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
                     errorMsg = exception.getMessage();
                 }
 
-                LOG.warn("Delete operation on instance '{}' failed: {}", instance.getServiceInstanceId(), errorMsg);
+                LOG.warn("Delete operation on instance '{}' failed: {}", instance != null ? instance.getServiceInstanceId() : null, errorMsg);
                 instance.setLastOperation(new LastOperationSerializer(OperationState.FAILED, errorMsg, true));
             }
 
             repository.save(instance);
         } catch (IOException e) {
-            LOG.error("Unable to find instance {} when delete completed async");
+            LOG.error("Unable to find instance {} when delete completed async", instanceId);
         }
     }
 }

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceService.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.servicebroker.service;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.model.PlanProxy;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.LastOperationSerializer;

--- a/src/main/java/com/emc/ecs/servicebroker/service/InstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/InstanceWorkflow.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.servicebroker.service;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.servicebroker.model.PlanProxy;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;

--- a/src/main/java/com/emc/ecs/servicebroker/service/NamespaceBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/NamespaceBindingWorkflow.java
@@ -1,15 +1,13 @@
 package com.emc.ecs.servicebroker.service;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;
-import com.emc.ecs.servicebroker.repository.ServiceInstanceBinding;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceAppBindingResponse;
 
-import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLEncoder;

--- a/src/main/java/com/emc/ecs/servicebroker/service/NamespaceInstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/NamespaceInstanceWorkflow.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.servicebroker.service;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.servicebroker.model.PlanProxy;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;

--- a/src/main/java/com/emc/ecs/servicebroker/service/RemoteConnectBindingWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/RemoteConnectBindingWorkflow.java
@@ -1,8 +1,7 @@
 package com.emc.ecs.servicebroker.service;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;
-import com.emc.ecs.servicebroker.repository.ServiceInstanceBinding;
 import com.emc.ecs.servicebroker.repository.ServiceInstanceRepository;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;

--- a/src/main/java/com/emc/ecs/servicebroker/service/RemoteConnectionInstanceWorkflow.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/RemoteConnectionInstanceWorkflow.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.servicebroker.service;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.servicebroker.model.PlanProxy;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;

--- a/src/test/java/com/emc/ecs/management/sdk/BaseUrlActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/BaseUrlActionTest.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.BaseUrl;
 import com.emc.ecs.management.sdk.model.BaseUrlInfo;

--- a/src/test/java/com/emc/ecs/management/sdk/BucketAclActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/BucketAclActionTest.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.BucketAcl;
 import com.emc.ecs.management.sdk.model.BucketUserAcl;

--- a/src/test/java/com/emc/ecs/management/sdk/BucketActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/BucketActionTest.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/com/emc/ecs/management/sdk/BucketQuotaActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/BucketQuotaActionTest.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.BucketQuotaDetails;
 import org.junit.After;

--- a/src/test/java/com/emc/ecs/management/sdk/BucketRetentionActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/BucketRetentionActionTest.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.DefaultBucketRetention;
 import org.junit.After;

--- a/src/test/java/com/emc/ecs/management/sdk/ConnectionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/ConnectionTest.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.common.EcsActionTest;
 import org.junit.After;
 import org.junit.Test;

--- a/src/test/java/com/emc/ecs/management/sdk/NFSExportActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/NFSExportActionTest.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.NFSExport;
 import org.junit.After;

--- a/src/test/java/com/emc/ecs/management/sdk/NamespaceActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/NamespaceActionTest.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.NamespaceUpdate;
 import org.junit.After;

--- a/src/test/java/com/emc/ecs/management/sdk/NamespaceQuotaActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/NamespaceQuotaActionTest.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.NamespaceQuotaDetails;
 import com.emc.ecs.management.sdk.model.NamespaceQuotaParam;

--- a/src/test/java/com/emc/ecs/management/sdk/NamespaceRetentionActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/NamespaceRetentionActionTest.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.RetentionClassCreate;
 import com.emc.ecs.management.sdk.model.RetentionClassDetails;

--- a/src/test/java/com/emc/ecs/management/sdk/ObjectUserActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/ObjectUserActionTest.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.common.EcsActionTest;
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/com/emc/ecs/management/sdk/ObjectUserSecretActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/ObjectUserSecretActionTest.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.UserSecretKey;
 import org.junit.After;

--- a/src/test/java/com/emc/ecs/management/sdk/ReplicationGroupActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/ReplicationGroupActionTest.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.management.sdk;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.model.DataServiceReplicationGroup;
 import org.junit.After;

--- a/src/test/java/com/emc/ecs/servicebroker/repository/ServiceInstanceBindingRepositoryTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/repository/ServiceInstanceBindingRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.servicebroker.repository;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.servicebroker.config.Application;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/emc/ecs/servicebroker/repository/ServiceInstanceRepositoryTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/repository/ServiceInstanceRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.servicebroker.repository;
 
-import com.emc.ecs.servicebroker.EcsManagementClientException;
-import com.emc.ecs.servicebroker.EcsManagementResourceNotFoundException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementResourceNotFoundException;
 import com.emc.ecs.servicebroker.config.Application;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingServiceTest.java
@@ -1,7 +1,7 @@
 package com.emc.ecs.servicebroker.service;
 
 import com.emc.ecs.management.sdk.model.UserSecretKey;
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.config.CatalogConfig;
 import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.ServiceInstance;

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceTest.java
@@ -2,7 +2,7 @@ package com.emc.ecs.servicebroker.service;
 
 import com.emc.ecs.management.sdk.*;
 import com.emc.ecs.management.sdk.model.*;
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.config.BrokerConfig;
 import com.emc.ecs.servicebroker.config.CatalogConfig;
 import com.emc.ecs.servicebroker.model.PlanProxy;
@@ -10,7 +10,6 @@ import com.emc.ecs.servicebroker.model.ServiceDefinitionProxy;
 import com.emc.ecs.servicebroker.repository.BucketWipeFactory;
 import com.emc.ecs.tool.BucketWipeOperations;
 import com.emc.ecs.tool.BucketWipeResult;
-import com.emc.object.s3.bean.Bucket;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/emc/ecs/servicebroker/service/ReclaimPolicyTests.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/ReclaimPolicyTests.java
@@ -6,7 +6,7 @@ import com.emc.ecs.management.sdk.model.BaseUrlInfo;
 import com.emc.ecs.management.sdk.model.DataServiceReplicationGroup;
 import com.emc.ecs.management.sdk.model.ObjectBucketCreate;
 import com.emc.ecs.management.sdk.model.UserSecretKey;
-import com.emc.ecs.servicebroker.EcsManagementClientException;
+import com.emc.ecs.servicebroker.exception.EcsManagementClientException;
 import com.emc.ecs.servicebroker.config.BrokerConfig;
 import com.emc.ecs.servicebroker.config.CatalogConfig;
 import com.emc.ecs.servicebroker.model.PlanProxy;


### PR DESCRIPTION
After upgrade to Spring Cloud Service Broker, errors from services didn't had an error description in response body. The issue turned out to be caused by missing error message in rethrown exceptions - so we had to pass the string as first constructor parameter.