### PR TITLE
Issue-185 Fixed Bucket Prefix when creating BucketQuota

### DIFF
--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -141,8 +141,8 @@ public class EcsService {
 
             if (parameters.containsKey(QUOTA) && parameters.get(QUOTA) != null) {
                 Map<String, Integer> quota = (Map<String, Integer>) parameters.get(QUOTA);
-                logger.info("Applying bucket quota on '{}': limit {}, warn {}", id, quota.get(LIMIT), quota.get(WARN));
-                BucketQuotaAction.create(connection, prefix(id), broker.getNamespace(), quota.get(LIMIT), quota.get(WARN));
+                logger.info("Applying bucket quota on '{}': limit {}, warn {}", prefix(bucketName), quota.get(LIMIT), quota.get(WARN));
+                BucketQuotaAction.create(connection, prefix(bucketName), broker.getNamespace(), quota.get(LIMIT), quota.get(WARN));
             }
 
             if (parameters.containsKey(DEFAULT_RETENTION) && parameters.get(DEFAULT_RETENTION) != null) {

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -57,6 +57,7 @@ public class Fixtures {
     public static final String BINDING_ID =
             "cf2f8326-3465-4810-9da1-54d328935b81";
     public static final String BUCKET_NAME = "testbucket1";
+    public static final String CUSTOM_BUCKET_NAME = "customtestbucket1";
     private static final String ACCESS_DURING_OUTAGE = "access-during-outage";
     private static final String ENCRYPTED = "encrypted";
     public static final String FILE_ACCESSIBLE = "file-accessible";

--- a/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/EcsServiceTest.java
@@ -231,7 +231,7 @@ public class EcsServiceTest {
                 .thenReturn(service);
 
         Map<String, Object> serviceSettings =
-                ecs.createBucket(BUCKET_NAME,  BUCKET_NAME, service, plan, new HashMap<>());
+                ecs.createBucket(BUCKET_NAME, CUSTOM_BUCKET_NAME, service, plan, new HashMap<>());
         assertTrue((Boolean) serviceSettings.get(ENCRYPTED));
         assertTrue((Boolean) serviceSettings.get(ACCESS_DURING_OUTAGE));
         assertTrue((Boolean) serviceSettings.get(FILE_ACCESSIBLE));
@@ -243,7 +243,7 @@ public class EcsServiceTest {
         BucketAction.create(same(connection), createCaptor.capture());
 
         ObjectBucketCreate create = createCaptor.getValue();
-        assertEquals(PREFIX + BUCKET_NAME, create.getName());
+        assertEquals(PREFIX + CUSTOM_BUCKET_NAME, create.getName());
         assertEquals(NAMESPACE, create.getNamespace());
         assertTrue(create.getIsEncryptionEnabled());
         assertTrue(create.getIsStaleAllowed());
@@ -272,7 +272,7 @@ public class EcsServiceTest {
         ServiceDefinitionProxy service = bucketServiceFixture();
         PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
 
-        Map<String, Object> serviceSettings = ecs.createBucket(BUCKET_NAME, BUCKET_NAME, service, plan, params);
+        Map<String, Object> serviceSettings = ecs.createBucket(BUCKET_NAME, CUSTOM_BUCKET_NAME, service, plan, params);
         Map<String, Integer> returnQuota = (Map<String, Integer>) serviceSettings.get(QUOTA);
         assertEquals(4, returnQuota.get(WARN).longValue());
         assertEquals(5, returnQuota.get(LIMIT).longValue());
@@ -286,14 +286,14 @@ public class EcsServiceTest {
         BucketAction.create(same(connection), createCaptor.capture());
 
         ObjectBucketCreate create = createCaptor.getValue();
-        assertEquals(PREFIX + BUCKET_NAME, create.getName());
+        assertEquals(PREFIX + CUSTOM_BUCKET_NAME, create.getName());
         assertTrue(create.getIsEncryptionEnabled());
         assertTrue(create.getIsStaleAllowed());
         assertTrue(create.getFilesystemEnabled());
         assertEquals(NAMESPACE, create.getNamespace());
 
         PowerMockito.verifyStatic(BucketQuotaAction.class, times(1));
-        BucketQuotaAction.create(same(connection), eq(PREFIX + BUCKET_NAME),
+        BucketQuotaAction.create(same(connection), eq(PREFIX + CUSTOM_BUCKET_NAME),
                 eq(NAMESPACE), eq(5), eq(4));
     }
 


### PR DESCRIPTION
When creating the BucketQuota for a Bucket with a custom name the code was incorrectly prefixing the bucket ID and NOT the bucket name.  This lead to the Create Quota attempting to create a quota on a bucket that doesn't exist.

This wasn't picked up by the Unit tests previously because `BUCKET_NAME` was used for both the ID and the name of the bucket being created therefore the original Unit tests still produced a valid result even if the prefix was incorrectly applied.  This has been fixed in this PR.

