### PR TITLE
Search Metadata editor in service definition on tile added

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,11 +358,6 @@ ECS Documentation provides following system metadata:
 | Size            | Integer   |  Size of the object.                                  |
 | CreateTime      | DateTime  |  Time at which the object was created.                |
 | LastModified    | DateTime  |  Time and date at which the object was last modified. |
-| ContentType     | String    |  -                                                    |
-| Expiration      | DateTime  |  -                                                    |
-| ContentEncoding | String    |  -                                                    |
-| Expires         | DateTime  |  -                                                    |
-| Retention       | Integer   |  -                                                    |
 
 System search metadata provided in `service-settings` block should be tagged with _System_ type, existing name and corresponding datatype.
 
@@ -372,7 +367,7 @@ User defined search metadata should be tagged with _User_ type, existing datatyp
 Prefix will be added to field name if it is not already there. 
 
 #### Metadata Search Datatypes
-When writing metadata to objects, client should provide data in format appropriate for each fields's datatype.
+When writing metadata to objects, client should provide data in format appropriate for each fields' datatype.
 ECS supports 4 types of datatype: _String_, _Integer_, _DateTime_ and _Decimal_.
 
 | Datatype | Description |

--- a/src/main/java/com/emc/ecs/servicebroker/config/CatalogConfig.java
+++ b/src/main/java/com/emc/ecs/servicebroker/config/CatalogConfig.java
@@ -1,6 +1,8 @@
 package com.emc.ecs.servicebroker.config;
 
 import com.emc.ecs.servicebroker.model.*;
+import com.emc.ecs.servicebroker.service.EcsService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -30,6 +32,7 @@ public class CatalogConfig {
     private List<ServiceDefinitionProxy> services;
     private Map<Integer, List<PlanProxy>> plans = new HashMap<>();
     private Map<Integer, Map<String, Object>> settings = new HashMap<>();
+    private Map<Integer, List<Map<String, String>>> searchMetadata = new HashMap<>();
 
     public CatalogConfig() {
         super();
@@ -55,6 +58,9 @@ public class CatalogConfig {
                 s.setPlans(plans.get(index));
             }
             if (settings.containsKey(index)) {
+                if (searchMetadata.containsKey(index)) {
+                    verifyAndPrepareSearchMetadata(index);
+                }
                 s.setServiceSettings(settings.get(index));
             }
             return s;
@@ -203,6 +209,37 @@ public class CatalogConfig {
         settings.put(TAGS, bucketTags);
 
         return settings;
+    }
+
+    public void setSearchMetadataCollection0(String searchMetadataCollectionJson) throws IOException {
+        this.searchMetadata.put(0, parseSearchMetadata(searchMetadataCollectionJson));
+    }
+
+    public void setSearchMetadataCollection1(String searchMetadataCollectionJson) throws IOException {
+        this.searchMetadata.put(1, parseSearchMetadata(searchMetadataCollectionJson));
+    }
+
+    public void setSearchMetadataCollection2(String searchMetadataCollectionJson) throws IOException {
+        this.searchMetadata.put(2, parseSearchMetadata(searchMetadataCollectionJson));
+    }
+
+    public void setSearchMetadataCollection3(String searchMetadataCollectionJson) throws IOException {
+        this.searchMetadata.put(3, parseSearchMetadata(searchMetadataCollectionJson));
+    }
+
+    public void setSearchMetadataCollection4(String searchMetadataCollectionJson) throws IOException {
+        this.searchMetadata.put(4, parseSearchMetadata(searchMetadataCollectionJson));
+    }
+
+    List<Map<String, String>> parseSearchMetadata(String searchMetadataJson) throws JsonProcessingException {
+        return objectMapper.readValue(searchMetadataJson, new TypeReference<List<Map<String, String>>>() {});
+    }
+
+    private void verifyAndPrepareSearchMetadata(int index) {
+        Map<String, Object> pars = settings.get(index);
+        pars.put(SEARCH_METADATA, searchMetadata.get(index));
+        EcsService.validateAndPrepareSearchMetadata(pars);
+        settings.put(index, pars);
     }
 
     public void setServices(List<ServiceDefinitionProxy> services) {

--- a/src/main/java/com/emc/ecs/servicebroker/config/CatalogConfig.java
+++ b/src/main/java/com/emc/ecs/servicebroker/config/CatalogConfig.java
@@ -231,7 +231,7 @@ public class CatalogConfig {
         this.searchMetadata.put(4, parseSearchMetadata(searchMetadataCollectionJson));
     }
 
-    List<Map<String, String>> parseSearchMetadata(String searchMetadataJson) throws JsonProcessingException {
+    public List<Map<String, String>> parseSearchMetadata(String searchMetadataJson) throws JsonProcessingException {
         return objectMapper.readValue(searchMetadataJson, new TypeReference<List<Map<String, String>>>() {});
     }
 

--- a/src/main/java/com/emc/ecs/servicebroker/model/SystemMetadataName.java
+++ b/src/main/java/com/emc/ecs/servicebroker/model/SystemMetadataName.java
@@ -5,12 +5,7 @@ public enum SystemMetadataName {
     LastModified(SearchMetadataDataType.DateTime),
     ObjectName(SearchMetadataDataType.String),
     Owner(SearchMetadataDataType.String),
-    Size(SearchMetadataDataType.Integer),
-    ContentType(SearchMetadataDataType.String),
-    Expiration(SearchMetadataDataType.DateTime),
-    ContentEncoding(SearchMetadataDataType.String),
-    Expires(SearchMetadataDataType.DateTime),
-    Retention(SearchMetadataDataType.Integer);
+    Size(SearchMetadataDataType.Integer);
 
     private SearchMetadataDataType dataType;
 

--- a/src/main/java/com/emc/ecs/servicebroker/model/SystemMetadataName.java
+++ b/src/main/java/com/emc/ecs/servicebroker/model/SystemMetadataName.java
@@ -8,7 +8,7 @@ public enum SystemMetadataName {
     Size(SearchMetadataDataType.Integer),
     ContentType(SearchMetadataDataType.String),
     Expiration(SearchMetadataDataType.DateTime),
-    ContentEnding(SearchMetadataDataType.String),
+    ContentEncoding(SearchMetadataDataType.String),
     Expires(SearchMetadataDataType.DateTime),
     Retention(SearchMetadataDataType.Integer);
 

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -765,7 +765,7 @@ public class EcsService {
         if (serviceMetadata == null) {
             return requestedMetadata;
         } else if (requestedMetadata == null) {
-            return null;
+            return serviceMetadata;
         } else {
             List<Map<String, String>> unmatchedMetadata = new ArrayList<>(requestedMetadata);
             for (Map<String, String> requestedMetadatum: requestedMetadata) {

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -512,7 +512,7 @@ public class EcsService {
     }
 
     @SuppressWarnings("unchecked")
-    static Map<String, Object> validateAndPrepareSearchMetadata(Map<String, Object> parameters) {
+    static public Map<String, Object> validateAndPrepareSearchMetadata(Map<String, Object> parameters) {
         if (parameters.containsKey(SEARCH_METADATA)) {
             parameters = new HashMap<>(parameters);  // don't modify original map
 

--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -761,13 +761,13 @@ public class EcsService {
     static List<Map<String, String>> mergeSearchMetadata(ServiceDefinitionProxy service, Map<String, Object> requestParameters) {
         List<Map<String, String>> serviceMetadata = (List<Map<String, String>>) service.getServiceSettings().get(SEARCH_METADATA);
         List<Map<String, String>> requestedMetadata = (List<Map<String, String>>)requestParameters.get(SEARCH_METADATA);
-        List<Map<String, String>> unmatchedMetadata = new ArrayList<>(requestedMetadata);
 
         if (serviceMetadata == null) {
             return requestedMetadata;
         } else if (requestedMetadata == null) {
             return null;
         } else {
+            List<Map<String, String>> unmatchedMetadata = new ArrayList<>(requestedMetadata);
             for (Map<String, String> requestedMetadatum: requestedMetadata) {
                 for (Map<String, String> serviceMetadatum: serviceMetadata) {
                     if (requestedMetadatum.get(SEARCH_METADATA_NAME).equals(serviceMetadatum.get(SEARCH_METADATA_NAME))) {

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -79,6 +79,8 @@ public class Fixtures {
     public static final int PAGE_SIZE = 32;
     public static final String SYSTEM_METADATA_NAME = "Size";
     public static final String SYSTEM_METADATA_TYPE = "Integer";
+    public static final String SYSTEM_METADATA_NAME2 = "Owner";
+    public static final String SYSTEM_METADATA_TYPE2 = "String";
     public static final String USER_METADATA_NAME = "my_meta";
     public static final String USER_METADATA_TYPE = "String";
     public static final String INVALID_METADATA_TYPE = "invalid_data_type";

--- a/src/test/java/com/emc/ecs/servicebroker/config/CatalogConfigTest.java
+++ b/src/test/java/com/emc/ecs/servicebroker/config/CatalogConfigTest.java
@@ -2,6 +2,8 @@ package com.emc.ecs.servicebroker.config;
 
 import com.emc.ecs.common.Fixtures;
 
+import com.emc.ecs.servicebroker.service.EcsServiceTest;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +31,9 @@ public class CatalogConfigTest {
 
     @Autowired
     private Catalog catalog;
+
+    @Autowired
+    private CatalogConfig catalogConfig;
 
     @Test
     public void testEcsBucket() {
@@ -99,6 +104,40 @@ public class CatalogConfigTest {
         List<Map<String, String>> expectedTags = Fixtures.listOfBucketTagsFixture();
 
         assertTrue(CollectionUtils.isEqualCollection(expectedTags, resultTags));
+    }
+
+    @Test
+    public void parseSearchMetadataTest() throws JsonProcessingException {
+        String searchMetadataString = buildSearchMetadataString(SEARCH_METADATA_TYPE_SYSTEM, SYSTEM_METADATA_NAME, SYSTEM_METADATA_TYPE,
+                SEARCH_METADATA_TYPE_USER, USER_METADATA_NAME, USER_METADATA_TYPE);
+
+        List<Map<String, String>> resultMetadata = catalogConfig.parseSearchMetadata(searchMetadataString);
+        List<Map<String, String>> expectedMetadata = EcsServiceTest.createListOfSearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SYSTEM_METADATA_NAME, SYSTEM_METADATA_TYPE,
+                SEARCH_METADATA_TYPE_USER, USER_METADATA_NAME, USER_METADATA_TYPE);
+
+        assertTrue(CollectionUtils.isEqualCollection(expectedMetadata, resultMetadata));
+    }
+
+    private String buildSearchMetadataString(String... args) {
+        if (args.length % 3 != 0) {
+            throw new IllegalArgumentException("Number of arguments should be multiple of three.");
+        }
+        if (args.length == 0) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder("[");
+        for (int i = 0; i < args.length; i += 3) {
+            if (i != 0) {
+                builder.append(',');
+            }
+            builder.append('{');
+            builder.append('\"' + SEARCH_METADATA_TYPE + "\":\"" + args[i] + "\",");
+            builder.append('\"' + SEARCH_METADATA_NAME + "\":\"" + args[i + 1] + "\",");
+            builder.append('\"' + SEARCH_METADATA_DATATYPE + "\":\"" + args[i + 2] + '\"');
+            builder.append('}');
+        }
+        builder.append(']');
+        return builder.toString();
     }
 
     private void testServiceDefinition(ServiceDefinition service, String id,

--- a/src/test/java/com/emc/ecs/servicebroker/service/MetadataSearchValidationTests.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/MetadataSearchValidationTests.java
@@ -137,7 +137,7 @@ public class MetadataSearchValidationTests {
     @Test
     public void nullAndNonemptyListsAreNotEqual() {
         List<SearchMetadata> list = Arrays.asList(
-                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.ContentEnding.name(), SearchMetadataDataType.String.name())
+                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.ContentEncoding.name(), SearchMetadataDataType.String.name())
         );
         assertFalse("Null and non empty metadata lists are not equal", EcsService.isEqualSearchMetadataList(null, list));
         assertFalse("Non empty list and null are not equal", EcsService.isEqualSearchMetadataList(list, null));
@@ -153,7 +153,7 @@ public class MetadataSearchValidationTests {
                 new SearchMetadata(SEARCH_METADATA_TYPE_USER, SOME_USER_METADATA_NAME, SearchMetadataDataType.Integer.name())
         );
         List<SearchMetadata> list2 = Arrays.asList(
-                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.ContentEnding.name(), SearchMetadataDataType.String.name())
+                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.ContentEncoding.name(), SearchMetadataDataType.String.name())
         );
         assertFalse("Lists with different entries are not equal", EcsService.isEqualSearchMetadataList(list1, list2));
     }

--- a/src/test/java/com/emc/ecs/servicebroker/service/MetadataSearchValidationTests.java
+++ b/src/test/java/com/emc/ecs/servicebroker/service/MetadataSearchValidationTests.java
@@ -83,14 +83,14 @@ public class MetadataSearchValidationTests {
     @Test
     public void validationFailsOnWrongDatatypeForSystemKey() {
         Map<String, String> m = new HashMap<>();
-        m.put(SEARCH_METADATA_NAME, SystemMetadataName.Expiration.name());
+        m.put(SEARCH_METADATA_NAME, SystemMetadataName.LastModified.name());
         m.put(SEARCH_METADATA_DATATYPE, SearchMetadataDataType.Integer.name());
 
         try {
             EcsService.validateAndPrepareSearchMetadata(parameters(m));
             Assert.fail();
         } catch (ServiceBrokerInvalidParametersException e) {
-            assertTrue(e.getMessage().contains("Invalid system search metadata '" + SystemMetadataName.Expiration.name() + "' datatype"));
+            assertTrue(e.getMessage().contains("Invalid system search metadata '" + SystemMetadataName.LastModified.name() + "' datatype"));
         }
     }
 
@@ -137,7 +137,7 @@ public class MetadataSearchValidationTests {
     @Test
     public void nullAndNonemptyListsAreNotEqual() {
         List<SearchMetadata> list = Arrays.asList(
-                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.ContentEncoding.name(), SearchMetadataDataType.String.name())
+                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.Owner.name(), SearchMetadataDataType.String.name())
         );
         assertFalse("Null and non empty metadata lists are not equal", EcsService.isEqualSearchMetadataList(null, list));
         assertFalse("Non empty list and null are not equal", EcsService.isEqualSearchMetadataList(list, null));
@@ -153,7 +153,7 @@ public class MetadataSearchValidationTests {
                 new SearchMetadata(SEARCH_METADATA_TYPE_USER, SOME_USER_METADATA_NAME, SearchMetadataDataType.Integer.name())
         );
         List<SearchMetadata> list2 = Arrays.asList(
-                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.ContentEncoding.name(), SearchMetadataDataType.String.name())
+                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.ObjectName.name(), SearchMetadataDataType.String.name())
         );
         assertFalse("Lists with different entries are not equal", EcsService.isEqualSearchMetadataList(list1, list2));
     }
@@ -161,12 +161,12 @@ public class MetadataSearchValidationTests {
     @Test
     public void sameMetadataListsAreEqual() {
         List<SearchMetadata> list1 = Arrays.asList(
-                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.ContentType.name(), SearchMetadataDataType.String.name()),
+                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.Owner.name(), SearchMetadataDataType.String.name()),
                 new SearchMetadata(SEARCH_METADATA_TYPE_USER, SOME_USER_METADATA_NAME, SearchMetadataDataType.Decimal.name())
         );
 
         List<SearchMetadata> list2 = Arrays.asList(
-                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.ContentType.name(), SearchMetadataDataType.String.name()),
+                new SearchMetadata(SEARCH_METADATA_TYPE_SYSTEM, SystemMetadataName.Owner.name(), SearchMetadataDataType.String.name()),
                 new SearchMetadata(SEARCH_METADATA_TYPE_USER, SOME_USER_METADATA_NAME, SearchMetadataDataType.Decimal.name())
         );
 


### PR DESCRIPTION
Adding support for metadata configuration edited in tile UI. Values are set through additional config variables due to UI framework limitations.