### PR TITLE
Returning OK when a binding file not found in repo

### DIFF
--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsServiceInstanceBindingService.java
@@ -80,7 +80,12 @@ public class EcsServiceInstanceBindingService implements ServiceInstanceBindingS
             ServiceInstanceBinding binding = repository.find(bindingId);
 
             if (binding == null) {
-                throw new ServiceInstanceBindingDoesNotExistException(bindingId);
+                LOG.warn("Binding '{}' not found, assuming already deleted", bindingId);
+                return Mono.just(
+                        DeleteServiceInstanceBindingResponse.builder()
+                                .async(false)
+                                .build()
+                );
             }
 
             LOG.debug("Binding found: {}", bindingId);


### PR DESCRIPTION
Doing same as with missing instance - returning OK response so that an instance could be removed from catalog.