### PR TITLE
ECSOSB-288 bucket wipe is failing from ecs-service-broker

### DIFF
--- a/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/servicebroker/service/EcsService.java
@@ -138,7 +138,7 @@ public class EcsService implements StorageService {
 
             logger.info("Started wipe of bucket '{}' in namespace '{}'", bucketName, namespace);
             BucketWipeResult result = bucketWipeFactory.newBucketWipeResult();
-            bucketWipe.deleteAllObjects(bucketName, "", result);
+            bucketWipe.deleteAllObjects(prefix(bucketName), "", result);
 
             String ns = namespace;
 


### PR DESCRIPTION
ecs service broker is passing bucketname without prefix, hence objectsvc is not able to find the bucket.
Before deleting the bucket it is looked up by bucketExists(prefix(bucketName), namespace),
however after finding the bucket exists deleteAllObjects is called with parameter bucketName without prefix, this is resulting in exception

c.e.e.s.s.EcsServiceInstanceService      : Error deleting service instance 6685f1ef-aa0d-49c7-9abb-bb23be22958e: The specified bucket does not exist.
org.springframework.cloud.servicebroker.exception.ServiceBrokerException: The specified bucket does not exist.
at com.emc.ecs.servicebroker.service.EcsService.wipeAndDeleteBucket(EcsService.java:147) ~[classes!/:na]
at com.emc.ecs.servicebroker.service.BucketInstanceWorkflow.delete(BucketInstanceWorkflow.java:66) ~[classes!/:na]

Testing:
Tested the above suggested fix ( passing bucketname with prefix) on my cluster, now bucket wipe succeeded and bucket could be deleted. 
```
2022-11-03 19:05:46.699  INFO 1 --- [nio-8080-exec-4] c.e.e.s.s.EcsServiceInstanceService      : Creating instance '3a599b48-ede8-4378-8345-7b26bcc7e602' with service definition 'ecs-bucket'(f3cbab6a-5172-4ff1-a5c7-72990f0ce2aa) and plan 'large'(13e90400-2ec7-41c2-9f6f-1484e0c01fd3)
2022-11-03 19:05:46.700  INFO 1 --- [nio-8080-exec-4] c.e.e.servicebroker.service.EcsService   : Creating bucket 'leader1-test8-3a599b48-ede8-4378-8345-7b26bcc7e602' with service 'ecs-bucket' plan 'large'(13e90400-2ec7-41c2-9f6f-1484e0c01fd3) and params \{base-url=null, service-type=bucket, access-during-outage=false, __request_context_properties={instance_name=project-data, namespace=test8, clusterid=a2c5aafc-dede-4da7-936d-d548be16925f}, head-type=s3, replication-group=sdp-rg, path-style-access=true, quota=\{limit=15, warn=12}, namespace=sdp-ns, name=test8, allowed-reclaim-policies=Delete, Fail, Detach, reclaim-policy=Delete, use-ssl=false}
2022-11-03 19:05:47.291  INFO 1 --- [nio-8080-exec-4] c.e.e.servicebroker.service.EcsService   : Applying bucket quota on 'leader1-test8-3a599b48-ede8-4378-8345-7b26bcc7e602' in 'sdp-ns': limit 15, warn 12
2022-11-03 19:05:47.472  INFO 1 --- [nio-8080-exec-4] c.e.e.s.r.ServiceInstanceRepository      : Saving instance to repository as service-instance/3a599b48-ede8-4378-8345-7b26bcc7e602.json
2022-11-03 19:05:47.492  INFO 1 --- [nio-8080-exec-4] o.s.c.s.c.ServiceInstanceController      : Creating a service instance
2022-11-03 19:05:47.493  INFO 1 --- [nio-8080-exec-4] o.s.c.s.c.ServiceInstanceController      : Creating a service instance succeeded
2022-11-03 19:05:56.932  INFO 1 --- [nio-8080-exec-5] e.e.s.s.EcsServiceInstanceBindingService : Creating binding '2cb953bd-4ab7-48f9-9f53-669733f13379' for service '3a599b48-ede8-4378-8345-7b26bcc7e602'
2022-11-03 19:05:57.032  INFO 1 --- [nio-8080-exec-5] c.e.e.servicebroker.service.EcsService   : Creating user 'leader1-test8-2cb953bd-4ab7-48f9-9f53-669733f13379' in namespace 'sdp-ns'
2022-11-03 19:05:57.168  INFO 1 --- [nio-8080-exec-5] c.e.e.servicebroker.service.EcsService   : Creating secret for user 'leader1-test8-2cb953bd-4ab7-48f9-9f53-669733f13379'
2022-11-03 19:05:57.372  INFO 1 --- [nio-8080-exec-5] c.e.e.servicebroker.service.EcsService   : Adding user 'leader1-test8-2cb953bd-4ab7-48f9-9f53-669733f13379' to bucket 'leader1-test8-3a599b48-ede8-4378-8345-7b26bcc7e602' in 'sdp-ns' with [full_control] access
2022-11-03 19:05:57.933  INFO 1 --- [nio-8080-exec-5] e.e.s.s.EcsServiceInstanceBindingService : Generating path-style S3 path for instance '3a599b48-ede8-4378-8345-7b26bcc7e602'
2022-11-03 19:05:58.001  INFO 1 --- [nio-8080-exec-5] s.c.s.c.ServiceInstanceBindingController : Creating a service instance binding
2022-11-03 19:05:58.002  INFO 1 --- [nio-8080-exec-5] s.c.s.c.ServiceInstanceBindingController : Creating a service instance binding succeeded
2022-11-03 19:09:11.726  INFO 1 --- [nio-8080-exec-7] e.e.s.s.EcsServiceInstanceBindingService : Deleting binding 2cb953bd-4ab7-48f9-9f53-669733f13379
2022-11-03 19:09:11.782  INFO 1 --- [nio-8080-exec-7] e.e.s.s.EcsServiceInstanceBindingService : Removing binding '2cb953bd-4ab7-48f9-9f53-669733f13379' user from bucket 'test8-3a599b48-ede8-4378-8345-7b26bcc7e602' in namespace 'sdp-ns'
2022-11-03 19:09:12.112  INFO 1 --- [nio-8080-exec-7] c.e.e.servicebroker.service.EcsService   : Deleting user 'test8-2cb953bd-4ab7-48f9-9f53-669733f13379' in namespace 'sdp-ns'
2022-11-03 19:09:13.376  INFO 1 --- [nio-8080-exec-7] s.c.s.c.ServiceInstanceBindingController : Deleting a service instance binding
2022-11-03 19:09:13.376  INFO 1 --- [nio-8080-exec-7] s.c.s.c.ServiceInstanceBindingController : Deleting a service instance binding succeeded
2022-11-03 19:09:22.915  INFO 1 --- [nio-8080-exec-8] c.e.e.s.s.EcsServiceInstanceService      : Deleting service instance '3a599b48-ede8-4378-8345-7b26bcc7e602'
2022-11-03 19:09:22.936  INFO 1 --- [nio-8080-exec-8] c.e.e.s.service.BucketInstanceWorkflow   : Reclaim Policy for bucket 'leader1-test8-3a599b48-ede8-4378-8345-7b26bcc7e602' is 'Delete', wiping and deleting bucket
2022-11-03 19:09:23.068  INFO 1 --- [nio-8080-exec-8] c.e.e.servicebroker.service.EcsService   : Adding user 'leader1-ecs-broker-user' to bucket 'leader1-test8-3a599b48-ede8-4378-8345-7b26bcc7e602' in 'sdp-ns' with [full_control] access
2022-11-03 19:09:23.526  INFO 1 --- [nio-8080-exec-8] c.e.e.servicebroker.service.EcsService   : Started wipe of bucket 'leader1-test8-3a599b48-ede8-4378-8345-7b26bcc7e602' in namespace 'sdp-ns'
2022-11-03 19:09:23.585  INFO 1 --- [nio-8080-exec-8] c.e.e.servicebroker.service.EcsService   : Bucket wipe succeeded, deleted 0 objects, Deleting bucket leader1-test8-3a599b48-ede8-4378-8345-7b26bcc7e602
2022-11-03 19:09:23.701  INFO 1 --- [nio-8080-exec-8] c.e.e.servicebroker.service.EcsService   : Deleting bucket 'leader1-test8-3a599b48-ede8-4378-8345-7b26bcc7e602' from namespace 'sdp-ns'
2022-11-03 19:09:23.861  INFO 1 --- [nio-8080-exec-8] c.e.e.s.s.EcsServiceInstanceService      : Setting last operation state 'In Progress - Deleting' on instance '3a599b48-ede8-4378-8345-7b26bcc7e602'
2022-11-03 19:09:23.862  INFO 1 --- [nio-8080-exec-8] c.e.e.s.r.ServiceInstanceRepository      : Saving instance to repository as service-instance/3a599b48-ede8-4378-8345-7b26bcc7e602.json
2022-11-03 19:09:23.891  INFO 1 --- [nio-8080-exec-8] c.e.e.s.s.EcsServiceInstanceService      : Setting last operation state 'Succeeded - Delete complete' on instance '3a599b48-ede8-4378-8345-7b26bcc7e602'
2022-11-03 19:09:23.893  INFO 1 --- [nio-8080-exec-8] c.e.e.s.r.ServiceInstanceRepository      : Saving instance to repository as service-instance/3a599b48-ede8-4378-8345-7b26bcc7e602.json
2022-11-03 19:09:23.907  INFO 1 --- [nio-8080-exec-8] o.s.c.s.c.ServiceInstanceController      : Deleting a service instance
2022-11-03 19:09:23.907  INFO 1 --- [nio-8080-exec-8] o.s.c.s.c.ServiceInstanceController      : Deleting a service instance succeeded
2022-11-03 19:09:25.377  INFO 1 --- [nio-8080-exec-9] c.e.e.s.s.EcsServiceInstanceService      : Operation for instance 3a599b48-ede8-4378-8345-7b26bcc7e602 completed successfully, deleting from repository
2022-11-03 19:09:25.377  INFO 1 --- [nio-8080-exec-9] c.e.e.s.r.ServiceInstanceRepository      : Deleting repository file service-instance/3a599b48-ede8-4378-8345-7b26bcc7e602.json
2022-11-03 19:09:25.382  INFO 1 --- [nio-8080-exec-9] o.s.c.s.c.ServiceInstanceController      : Getting service instance last operation
2022-11-03 19:09:25.383  INFO 1 --- [nio-8080-exec-9] o.s.c.s.c.ServiceInstanceController      : Getting service instance last operation succeeded
```